### PR TITLE
feat: interactive setup.sh for OpenSearch + Bedrock + S3 Vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,34 @@ For optimal RAG performance, configure hybrid search with appropriate weights:
 - BM25 Minimum Should Match: "2" or "70%" for precision
 - Use Japanese NLP: true (enables kuromoji tokenizer)
 
+## Automated Setup (setup.sh)
+
+Use the interactive `setup.sh` to configure AWS OpenSearch security, create/mapping roles, create the target index, and grant IAM permissions for Bedrock and S3 Vectors. This script drives AWS CLI and signs OpenSearch Security API calls with SigV4.
+
+Prerequisites
+- AWS CLI v2 configured (credentials/profile with permission to update the domain and IAM)
+- OpenSearch domain reachable (either VPC endpoint directly, or local port‑forward to `https://localhost:9200` with Host/SNI set to the VPC endpoint)
+
+Run
+```bash
+bash setup.sh
+```
+
+What it asks
+- AWS Account ID, OpenSearch domain/region, endpoint usage (direct vs. localhost:9200), IAM role ARNs (RAG runtime, optional master/admin), index name, S3 Vectors bucket/index/region, Bedrock region and model IDs.
+
+What it does
+- Updates the domain access policy to allow specified IAM roles
+- (Optional) Sets AdvancedSecurity MasterUserARN
+- Creates/updates OpenSearch role `kibela_rag_role` with cluster health + CRUD/bulk on <index>* and maps backend_roles to your IAM roles
+- Creates the index if missing with Japanese analyzers and `knn_vector` (1024, lucene, cosinesimil)
+- (Optional) Temporarily maps `all_access` to the RAG role for troubleshooting
+- Adds IAM inline policies to the RAG role for Bedrock InvokeModel and S3 Vectors bucket/index operations
+
+Notes
+- If you use local port‑forwarding, the script sets the Host header to the VPC endpoint so SigV4 validation works against `https://localhost:9200`.
+- The `all_access` mapping is optional and intended for short‑term troubleshooting; remove it after verification.
+
 ## License
 
 For license information, please refer to the LICENSE file in the repository.

--- a/internal/s3vector/client.go
+++ b/internal/s3vector/client.go
@@ -86,15 +86,24 @@ func (s *S3VectorService) StoreVector(ctx context.Context, vectorData *commontyp
 		float32Embedding[i] = float32(v)
 	}
 
-	// Prepare metadata for S3 Vectors - include content field
-	metadataMap := map[string]interface{}{
-		"title":      vectorData.Metadata.Title,
-		"category":   vectorData.Metadata.Category,
-		"file_path":  vectorData.Metadata.FilePath,
-		"created_at": vectorData.CreatedAt.Format(time.RFC3339),
-		"word_count": vectorData.Metadata.WordCount,
-		"content":    vectorData.Content, // Add content field
-	}
+    // Prepare metadata for S3 Vectors
+    // NOTE: S3 Vectorsのフィルタ可能メタデータは最大2048バイト制限があるため
+    // 大きい本文は入れず、短い抜粋のみを保存する
+    metadataMap := map[string]interface{}{
+        "title":      vectorData.Metadata.Title,
+        "category":   vectorData.Metadata.Category,
+        "file_path":  vectorData.Metadata.FilePath,
+        "created_at": vectorData.CreatedAt.Format(time.RFC3339),
+        "word_count": vectorData.Metadata.WordCount,
+    }
+
+    // Add short excerpt of content to avoid metadata size limits (<= 2048 bytes in total)
+    if vectorData.Content != "" {
+        excerpt := truncateUTF8ByBytes(vectorData.Content, 512) // up to 512 bytes excerpt
+        if excerpt != "" {
+            metadataMap["content_excerpt"] = excerpt
+        }
+    }
 
 	// Add reference if available
 	if vectorData.Metadata.Reference != "" {
@@ -138,6 +147,38 @@ func (s *S3VectorService) StoreVector(ctx context.Context, vectorData *commontyp
 	}
 
 	return nil
+}
+
+// truncateUTF8ByBytes returns a string truncated so that its UTF-8 byte length
+// does not exceed the specified limit. It preserves rune boundaries.
+func truncateUTF8ByBytes(s string, limit int) string {
+    if limit <= 0 || len(s) == 0 {
+        return ""
+    }
+    // Fast path: already within limit
+    if len([]byte(s)) <= limit {
+        return s
+    }
+    // Walk runes and accumulate until exceeding limit
+    var (
+        total int
+        end   int
+    )
+    for i, r := range s {
+        // size in bytes of this rune in UTF-8
+        var buf [4]byte
+        n := copy(buf[:], string(r))
+        if total+n > limit {
+            end = i
+            break
+        }
+        total += n
+        end = i + n // i is byte index of rune start; but range over string gives byte index, so increment by n
+    }
+    if end <= 0 || end > len(s) {
+        end = len(s)
+    }
+    return s[:end]
 }
 
 // ValidateAccess checks if S3 Vector bucket is accessible

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -109,10 +109,6 @@ const (
 
 // Config represents the vectorizer configuration
 type Config struct {
-	// Kibela configuration
-	KibelaToken string `json:"kibela_token" env:"KIBELA_TOKEN,required=true"`
-	KibelaTeam  string `json:"kibela_team" env:"KIBELA_TEAM,required=true"`
-
 	// AWS S3 Vectors configuration
 	AWSS3VectorBucket    string        `json:"aws_s3_vector_bucket" env:"AWS_S3_VECTOR_BUCKET,required=true"`
 	AWSS3VectorIndex     string        `json:"aws_s3_vector_index" env:"AWS_S3_VECTOR_INDEX,required=true"`

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# setup.sh - Interactive setup for OpenSearch + Bedrock + S3 Vectors (AWS CLI + SigV4 curl)
+set -euo pipefail
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' not found in PATH"; exit 1; }
+}
+require aws
+require curl
+
+# -------- Helpers --------
+ask() {
+  local prompt="$1"; local def="${2-}"; local showdef=""
+  [ -n "$def" ] && showdef=" [$def]"
+  read -r -p "$prompt$showdef: " REPLY
+  if [ -z "$REPLY" ] && [ -n "$def" ]; then REPLY="$def"; fi
+}
+
+confirm() {
+  local msg="${1:-Proceed?}"
+  read -r -p "$msg [y/N]: " ans; case "${ans,,}" in y|yes) return 0;; *) return 1;; esac
+}
+
+sts_acct() { aws sts get-caller-identity --query 'Account' --output text 2>/dev/null || true; }
+basename_arn() { printf "%s\n" "$1" | awk -F'/' '{print $NF}'; }
+
+os_curl() {
+  # os_curl METHOD PATH [extra curl args...]
+  local method="${1:-GET}"; shift
+  local path="${1:-/}"; shift
+  local args=(
+    --silent --show-error --fail
+    --aws-sigv4 "aws:amz:${AWS_REGION}:es"
+    --user "${AKID}:${SECRET}"
+    -H "host: ${OS_HOST}"
+    -H "Content-Type: application/json"
+    -X "$method" "${OS_EP}${path}"
+  )
+  if [ -n "${SESSION:-}" ]; then args+=(-H "x-amz-security-token: ${SESSION}"); fi
+  curl "${args[@]}" "$@"
+}
+
+wait_domain_apply() {
+  echo "Waiting for domain config to apply..."
+  until [ "$(aws opensearch describe-domain --region "$AWS_REGION" --domain-name "$OS_DOMAIN" \
+              --query 'DomainStatus.Processing' --output text)" = "False" ]; do
+    sleep 6
+    printf "."
+  done
+  echo " done"
+}
+
+# -------- Gather inputs --------
+echo "== AWS account and region inputs =="
+ACCT_DEF="$(sts_acct)"; ask "AWS Account ID" "${ACCT_DEF:-}"
+ACCOUNT_ID="$REPLY"
+ask "OpenSearch domain name" "rag"; OS_DOMAIN="$REPLY"
+ask "OpenSearch region" "ap-northeast-1"; AWS_REGION="$REPLY"
+
+echo "== OpenSearch endpoint selection =="
+ask "Resolve VPC endpoint from domain via AWS CLI? (y/N)" "y"; RESOLVE="${REPLY,,}"
+if [ "$RESOLVE" = "y" ] || [ "$RESOLVE" = "yes" ]; then
+  OS_HOST="$(aws opensearch describe-domain --region "$AWS_REGION" --domain-name "$OS_DOMAIN" \
+            --query 'DomainStatus.Endpoints.vpc' --output text)"
+  if [ -z "$OS_HOST" ] || [ "$OS_HOST" = "None" ]; then
+    echo "ERROR: Could not resolve VPC endpoint. Provide manually."
+    ask "OpenSearch VPC endpoint host (e.g., vpc-xxxx.es.amazonaws.com)" ""; OS_HOST="$REPLY"
+  fi
+else
+  ask "OpenSearch VPC endpoint host (e.g., vpc-xxxx.es.amazonaws.com)" ""; OS_HOST="$REPLY"
+fi
+
+ask "Use local port-forward (https://localhost:9200)? (y/N)" "y"; USE_PF="${REPLY,,}"
+if [ "$USE_PF" = "y" ] || [ "$USE_PF" = "yes" ]; then
+  OS_EP="https://localhost:9200"
+  echo "Note: Ensure Host/SNI is '${OS_HOST}' in SigV4 curl (this script sets Host header)."
+else
+  OS_EP="https://${OS_HOST}"
+fi
+
+echo "== Principals (IAM role ARNs) =="
+ask "Master security admin role ARN (MasterUserARN). Leave empty to skip" ""
+ROLE_MASTER_ARN="${REPLY:-}"
+ask "RAG compute role ARN (e.g., EC2/SSM role)" ""
+ROLE_RAG_ARN="$REPLY"
+ask "Additional admin role ARN to allow (optional)" ""
+ROLE_EXTRA_ARN="${REPLY:-}"
+
+echo "== Index and roles =="
+ask "OpenSearch index name (for RAG docs)" "kibela"; OS_INDEX="$REPLY"
+ask "Grant temporary 'all_access' to RAG role for bulk troubleshooting? (y/N)" "y"; ADD_ALL_ACCESS="${REPLY,,}"
+
+echo "== S3 Vectors =="
+ask "S3 Vectors region" "us-east-1"; S3V_REGION="$REPLY"
+ask "S3 Vectors bucket name" "rag"; S3V_BUCKET="$REPLY"
+ask "S3 Vectors index name" "$OS_INDEX"; S3V_INDEX="$REPLY"
+
+echo "== Bedrock (models and region) =="
+ask "Bedrock region" "us-east-1"; BDR_REGION="$REPLY"
+ask "Embedding model ID" "amazon.titan-embed-text-v2:0"; EMB_MODEL_ID="$REPLY"
+ask "Chat model ID (optional, leave empty to skip)" "anthropic.claude-3-5-sonnet-20240620-v1:0"; CHAT_MODEL_ID="$REPLY"
+
+# -------- Show plan and confirm --------
+cat <<PLAN
+
+Plan:
+- OpenSearch domain: arn:aws:es:${AWS_REGION}:${ACCOUNT_ID}:domain/${OS_DOMAIN}
+- OpenSearch host:  ${OS_HOST}
+- OpenSearch entry: ${OS_EP}
+- MasterUserARN:    ${ROLE_MASTER_ARN:-"(skip)"}
+- Allow principals: ${ROLE_RAG_ARN}${ROLE_EXTRA_ARN:+, ${ROLE_EXTRA_ARN}}
+- Create/Update role: kibela_rag_role (cluster:monitor/health + CRUD/bulk on ${OS_INDEX}*)
+- Map backend_roles: [RAG role${ROLE_EXTRA_ARN:+, Extra role}]
+- Create index if missing: ${OS_INDEX}
+- Temp map all_access to RAG role: ${ADD_ALL_ACCESS}
+- IAM put-role-policy on $(basename_arn "${ROLE_RAG_ARN}"):
+  - Bedrock (${BDR_REGION}): ${EMB_MODEL_ID}${CHAT_MODEL_ID:+, ${CHAT_MODEL_ID}}
+  - S3 Vectors (${S3V_REGION}): bucket=${S3V_BUCKET}, index=${S3V_INDEX}
+PLAN
+
+confirm "Proceed with the above plan?" || { echo "Aborted."; exit 1; }
+
+# -------- Resolve credentials for SigV4 curl --------
+AKID="$(aws configure get aws_access_key_id || true)"
+SECRET="$(aws configure get aws_secret_access_key || true)"
+SESSION="$(aws configure get aws_session_token || true)"
+[ -z "$AKID" ] && { echo "ERROR: No AWS credentials configured"; exit 1; }
+
+echo "== Caller identity =="
+aws sts get-caller-identity || true
+
+# -------- 1) Update domain access policy --------
+PRINCIPALS="\"${ROLE_RAG_ARN}\""
+[ -n "$ROLE_EXTRA_ARN" ] && PRINCIPALS="${PRINCIPALS},\"${ROLE_EXTRA_ARN}\""
+POLICY_JSON=$(cat <<JSON
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "AWS": [ ${PRINCIPALS} ] },
+    "Action": "es:*",
+    "Resource": "arn:aws:es:${AWS_REGION}:${ACCOUNT_ID}:domain/${OS_DOMAIN}/*"
+  }]
+}
+JSON
+)
+aws opensearch update-domain-config \
+  --region "$AWS_REGION" --domain-name "$OS_DOMAIN" \
+  --access-policies "$POLICY_JSON" >/dev/null
+
+# -------- 2) Set MasterUserARN (optional) --------
+if [ -n "$ROLE_MASTER_ARN" ]; then
+  aws opensearch update-domain-config \
+    --region "$AWS_REGION" --domain-name "$OS_DOMAIN" \
+    --advanced-security-options "MasterUserOptions={MasterUserARN=\"${ROLE_MASTER_ARN}\"}" >/dev/null || true
+fi
+
+# -------- 3) Wait for apply --------
+wait_domain_apply
+
+# -------- 4) Create/Update kibela_rag_role --------
+ROLE_BODY=$(cat <<'JSON'
+{
+  "cluster_permissions": [ "cluster:monitor/health" ],
+  "index_permissions": [{
+    "index_patterns": ["kibela*"],
+    "allowed_actions": [
+      "crud",
+      "create_index",
+      "indices:data/write/bulk",
+      "indices:data/write/index",
+      "indices:admin/mapping/put",
+      "indices:admin/exists",
+      "indices:admin/get",
+      "indices:monitor/*"
+    ]
+  }]
+}
+JSON
+)
+# Replace index pattern with chosen index prefix
+ROLE_BODY="${ROLE_BODY//kibela*/${OS_INDEX}*}"
+printf '%s' "$ROLE_BODY" > /tmp/kibela_role.json
+os_curl PUT "/_plugins/_security/api/roles/kibela_rag_role" --data @/tmp/kibela_role.json || true
+
+# -------- 5) Role mapping for kibela_rag_role --------
+MAP_BODY=$(cat <<JSON
+{"backend_roles":["${ROLE_RAG_ARN}"${ROLE_EXTRA_ARN:+,\"${ROLE_EXTRA_ARN}\"}],"hosts":[],"users":[]}
+JSON
+)
+printf '%s' "$MAP_BODY" > /tmp/kibela_rolesmapping.json
+os_curl PUT "/_plugins/_security/api/rolesmapping/kibela_rag_role" --data @/tmp/kibela_rolesmapping.json || true
+
+# -------- 6) Create index if missing --------
+INDEX_BODY=$(cat <<'JSON'
+{
+  "settings": { "index": { "knn": true } },
+  "mappings": {
+    "properties": {
+      "title":   { "type":"text", "analyzer":"kuromoji" },
+      "content": { "type":"text", "analyzer":"kuromoji" },
+      "body":    { "type":"text", "analyzer":"kuromoji" },
+      "category":   { "type":"keyword" },
+      "tags":       { "type":"keyword" },
+      "created_at": { "type":"date"    },
+      "updated_at": { "type":"date"    },
+      "embedding": {
+        "type":"knn_vector",
+        "dimension": 1024,
+        "method": { "engine":"lucene", "space_type":"cosinesimil", "name":"hnsw", "parameters": {} }
+      }
+    }
+  }
+}
+JSON
+)
+printf '%s' "$INDEX_BODY" > /tmp/os_index.json
+if ! os_curl HEAD "/${OS_INDEX}" >/dev/null 2>&1; then
+  os_curl PUT "/${OS_INDEX}" --data @/tmp/os_index.json
+fi
+
+# -------- 7) Temporary: map all_access to RAG role (optional) --------
+if [ "$ADD_ALL_ACCESS" = "y" ] || [ "$ADD_ALL_ACCESS" = "yes" ]; then
+  printf '{"backend_roles":["%s"],"hosts":[],"users":[]}\n' "$ROLE_RAG_ARN" > /tmp/all_access_rolesmapping.json
+  os_curl PUT "/_plugins/_security/api/rolesmapping/all_access" --data @/tmp/all_access_rolesmapping.json || true
+fi
+
+# -------- 8) IAM inline policies (Bedrock + S3 Vectors) --------
+ROLE_RAG_NAME="$(basename_arn "$ROLE_RAG_ARN")"
+
+# Bedrock
+if [ -n "$EMB_MODEL_ID" ] || [ -n "$CHAT_MODEL_ID" ]; then
+  BDR_STATEMENTS=""
+  if [ -n "$EMB_MODEL_ID" ]; then
+    BDR_STATEMENTS="${BDR_STATEMENTS}{\"Sid\":\"InvokeEmb\",\"Effect\":\"Allow\",\"Action\":[\"bedrock:InvokeModel\",\"bedrock:InvokeModelWithResponseStream\"],\"Resource\":[\"arn:aws:bedrock:${BDR_REGION}::foundation-model/${EMB_MODEL_ID}\"]}"
+  fi
+  if [ -n "$CHAT_MODEL_ID" ]; then
+    [ -n "$BDR_STATEMENTS" ] && BDR_STATEMENTS="${BDR_STATEMENTS},"
+    BDR_STATEMENTS="${BDR_STATEMENTS}{\"Sid\":\"InvokeChat\",\"Effect\":\"Allow\",\"Action\":[\"bedrock:InvokeModel\",\"bedrock:InvokeModelWithResponseStream\"],\"Resource\":[\"arn:aws:bedrock:${BDR_REGION}::foundation-model/${CHAT_MODEL_ID}\"]}"
+  fi
+  printf '{ "Version":"2012-10-17", "Statement":[%s] }\n' "$BDR_STATEMENTS" > /tmp/bedrock-invoke.json
+  aws iam put-role-policy --role-name "$ROLE_RAG_NAME" --policy-name AllowBedrockInvoke --policy-document file:///tmp/bedrock-invoke.json
+fi
+
+# S3 Vectors
+cat > /tmp/s3vectors-inline.json <<JSON
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "S3VectorsBucketAccess",
+      "Effect": "Allow",
+      "Action": ["s3vectors:GetVectorBucket","s3vectors:ListIndexes"],
+      "Resource": "arn:aws:s3vectors:${S3V_REGION}:${ACCOUNT_ID}:bucket/${S3V_BUCKET}"
+    },
+    {
+      "Sid": "S3VectorsIndexAccess",
+      "Effect": "Allow",
+      "Action": ["s3vectors:GetIndex","s3vectors:CreateIndex","s3vectors:DeleteIndex","s3vectors:PutVectors","s3vectors:DeleteVectors","s3vectors:ListVectors","s3vectors:GetVectors","s3vectors:QueryVectors"],
+      "Resource": "arn:aws:s3vectors:${S3V_REGION}:${ACCOUNT_ID}:bucket/${S3V_BUCKET}/index/${S3V_INDEX}"
+    }
+  ]
+}
+JSON
+aws iam put-role-policy --role-name "$ROLE_RAG_NAME" --policy-name "AllowS3Vectors_${S3V_BUCKET}_${S3V_INDEX}" --policy-document file:///tmp/s3vectors-inline.json
+
+# -------- 9) Checks --------
+echo "== OpenSearch account roles =="
+os_curl GET "/_plugins/_security/api/account" || true
+echo
+echo "== Cluster health =="
+os_curl GET "/_cluster/health?pretty" || true
+echo
+echo "== Index list =="
+os_curl GET "/_cat/indices/${OS_INDEX}?v" || true
+echo
+echo "Setup completed."
+


### PR DESCRIPTION
# feat: interactive setup.sh for OpenSearch + Bedrock + S3 Vectors

## 概要 / Overview
- 対話式の `setup.sh` を追加し、OpenSearch セキュリティ設定（アクセスポリシー/ロール/ロールマッピング）、インデックス作成、Bedrock・S3 Vectors の IAM 付与を一括自動化
- README.md / README_ja.md に `setup.sh` の使い方を追記
- S3 Vectors メタデータ 2KB 制限回避（`content` 全文ではなく 512B 抜粋 `content_excerpt` を保存）
- OpenSearch 役割 `kibela_rag_role` の権限を CRUD/Bulk/monitor 系で拡充

## 変更内容 / Changes
- add: `setup.sh`（対話式・SigV4 cURL + AWS CLI 実行）
- docs: README.md / README_ja.md に "Automated Setup (setup.sh) / セットアップ自動化（setup.sh）" セクション追加
- fix(s3vectors): 2048 bytes 超のフィルタ可能メタデータを避けるため `content_excerpt` を導入（UTF-8 バイト長で切り詰め）
- chore(opensearch): `kibela_rag_role` に `crud`, `indices:data/write/bulk`, `indices:admin/*`, `indices:monitor/*` 等を付与

## 動機 / Motivation
- 環境依存の手作業（OpenSearch セキュリティ/インデックス/IAM 付与）をスクリプト化し、アカウント/ドメイン/バケットが異なる環境でも対話式に再現可能にするため
- 大きなメタデータによる S3 Vectors の 400 Validation を回避

## 影響範囲 / Impact
- `internal/s3vector/client.go` のメタデータ保存仕様が変更（content → content_excerpt）。検索ロジックには影響なし
- OpenSearch への書き込みは `kibela_rag_role` 権限で可能に（暫定で `all_access` 付与オプションは setup 時のみ）

## 破壊的変更 / Breaking Changes
- [x] なし / None

## テスト / Testing
- Bedrock Titan v2(us-east-1) で埋め込み生成 OK
- S3 Vectors への PutVectors で 2KB 超過が発生しないことを確認
- OpenSearch: `/_cluster/health` 200, `HEAD /<index>` 200, bulk 書込み OK（暫定 `all_access` で切り分け済）

## チェックリスト / Checklist
- [x] 期待通りに動作することを確認
- [x] ドキュメント更新（README.md / README_ja.md）
- [x] 変更範囲が限定的であることを確認
