### PR TITLE
feat(search): add URL-aware search with exact match capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ markdown/*.md
 ragent
 .spec-workflow
 opencode.json
+doc/debug.md

--- a/README_ja.md
+++ b/README_ja.md
@@ -168,6 +168,33 @@ RAGent query -q "authentication" --filter '{"type":"security"}' --json
 RAGent query -q "database optimization" --top-k 20
 ```
 
+#### URL対応検索
+
+RAGent はクエリ内の HTTP/HTTPS URL を検出し、まず `reference` フィールドに対する完全一致の term query を実行します。
+
+- URL が検出され一致した場合は `search_method` が `"url_exact_match"` となり、URL に紐づく結果のみを即座に返します。
+- term query が失敗またはヒットゼロの場合はハイブリッド検索 (`"hybrid_search"`) にフォールバックし、`fallback_reason` に理由 (`term_query_error` / `term_query_no_results`) を記録します。
+- CLI の `--json` 出力、Slack Bot、MCP ツールのレスポンスには `search_method`, `url_detected`, `fallback_reason` が含まれ、検索経路を確認できます。
+
+```bash
+RAGent query --json -q "https://example.com/doc のタイトルを教えて"
+```
+
+JSON レスポンス例:
+
+```json
+{
+  "search_method": "url_exact_match",
+  "url_detected": true,
+  "fallback_reason": "",
+  "results": [
+    { "title": "Example Doc", "reference": "https://example.com/doc" }
+  ]
+}
+```
+
+URL が見つからない場合や一致しなかった場合は `search_method` が `"hybrid_search"` になり、通常の BM25 + ベクトル融合結果が返されます。
+
 ### 3. list - ベクトル一覧表示
 
 S3 Vector Indexに保存されているベクトルの一覧を表示します。

--- a/cmd/query_test_helpers.go
+++ b/cmd/query_test_helpers.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	commontypes "github.com/ca-srg/ragent/internal/types"
+)
+
+type QueryDependencyOverrides struct {
+	LoadConfig          appConfigLoader
+	LoadAWSConfig       awsConfigLoader
+	NewEmbeddingClient  bedrockClientFactory
+	NewOpenSearchClient openSearchClientFactory
+	NewHybridEngine     hybridEngineFactory
+}
+
+func OverrideQueryDependencies(overrides QueryDependencyOverrides) func() {
+	prevLoadConfig := loadAppConfig
+	prevLoadAWS := loadAWSConfig
+	prevEmbedding := newEmbeddingClient
+	prevOpenSearch := newOpenSearchClient
+	prevHybrid := newHybridEngine
+
+	if overrides.LoadConfig != nil {
+		loadAppConfig = overrides.LoadConfig
+	}
+	if overrides.LoadAWSConfig != nil {
+		loadAWSConfig = overrides.LoadAWSConfig
+	}
+	if overrides.NewEmbeddingClient != nil {
+		newEmbeddingClient = overrides.NewEmbeddingClient
+	}
+	if overrides.NewOpenSearchClient != nil {
+		newOpenSearchClient = overrides.NewOpenSearchClient
+	}
+	if overrides.NewHybridEngine != nil {
+		newHybridEngine = overrides.NewHybridEngine
+	}
+
+	return func() {
+		loadAppConfig = prevLoadConfig
+		loadAWSConfig = prevLoadAWS
+		newEmbeddingClient = prevEmbedding
+		newOpenSearchClient = prevOpenSearch
+		newHybridEngine = prevHybrid
+	}
+}
+
+// Helpers to build default override closures without importing internal types in tests.
+func DefaultLoadConfigOverride(cfg *commontypes.Config, err error) appConfigLoader {
+	return func() (*commontypes.Config, error) {
+		return cfg, err
+	}
+}
+
+func DefaultAWSConfigOverride(cfg aws.Config, err error) awsConfigLoader {
+	return func(ctx context.Context, optFns ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
+		return cfg, err
+	}
+}
+
+func EmbeddingClientOverride(factory bedrockClientFactory) bedrockClientFactory {
+	return factory
+}
+
+func OpenSearchClientOverride(factory openSearchClientFactory) openSearchClientFactory {
+	return factory
+}
+
+func HybridEngineOverride(factory hybridEngineFactory) hybridEngineFactory {
+	return factory
+}
+
+func ResetQueryState() {
+	queryText = ""
+	topK = 10
+	outputJSON = false
+	filterQuery = ""
+	searchMode = "hybrid"
+	indexName = ""
+	bm25Weight = 0.5
+	vectorWeight = 0.5
+	fusionMethod = "rrf"
+	useJapaneseNLP = false
+	timeout = 30
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,9 +5,9 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "mdrag",
-	Short: "mdRAG - RAG system builder for Markdown documents",
-	Long: `mdRAG is a CLI tool for building a RAG (Retrieval-Augmented Generation) system 
+	Use:   "ragent",
+	Short: "RAGent - RAG system builder for Markdown documents",
+	Long: `RAGent is a CLI tool for building a RAG (Retrieval-Augmented Generation) system 
 from Markdown documents using hybrid search capabilities (BM25 + vector search) 
 with Amazon S3 Vectors and OpenSearch.`,
 }

--- a/doc/vectorize.md
+++ b/doc/vectorize.md
@@ -1,0 +1,552 @@
+# vectorize コマンド詳細解説
+
+## 概要
+
+`vectorize` コマンドは、Markdownドキュメントをベクトル化し、Amazon S3 VectorsおよびOpenSearchに保存するRAGent の中核機能です。このドキュメントでは、1つのMarkdownファイルがどのように処理され、検索可能なベクトルデータに変換されるかを、RAG（Retrieval-Augmented Generation）の初学者向けに詳細に解説します。
+
+## RAGとベクトル化の基礎
+
+### RAGとは？
+
+RAG（Retrieval-Augmented Generation）は、大規模言語モデル（LLM）の回答精度を向上させる技術です。LLMに質問する前に、関連する文書を検索して文脈として与えることで、より正確で具体的な回答を生成できます。
+
+### ベクトル化とは？
+
+ベクトル化（Embedding）は、テキストを数値の配列（ベクトル）に変換する処理です。例えば、「機械学習」というテキストは `[0.123, -0.456, 0.789, ...]` のような1024個の数値で表現されます。意味が似ているテキストは、似たようなベクトルになるため、数学的に類似度を計算できます。
+
+### ハイブリッド検索とは？
+
+RAGentは2つの検索手法を組み合わせています：
+
+1. **ベクトル検索（Dense検索）**: 意味的な類似性で検索
+2. **BM25検索**: キーワードマッチで検索
+
+両方を組み合わせることで、より高精度な検索を実現します。
+
+## 全体の処理フロー
+
+```mermaid
+graph TB
+    Start([vectorize コマンド実行]) --> ValidateFlags[フラグ検証]
+    ValidateFlags --> LoadConfig[設定読み込み]
+    LoadConfig --> CheckMode{モード確認}
+
+    CheckMode -->|通常モード| ScanDir[ディレクトリスキャン]
+    CheckMode -->|フォローモード| FollowLoop[30分間隔で繰り返し実行]
+
+    FollowLoop --> ScanDir
+
+    ScanDir --> FindFiles[Markdownファイル検出]
+    FindFiles --> CheckBackend{バックエンド確認}
+
+    CheckBackend -->|S3 Vector のみ| ProcessS3[S3 Vector処理]
+    CheckBackend -->|デュアルバックエンド| ProcessDual[S3 Vector + OpenSearch処理]
+
+    ProcessS3 --> Concurrent[並行処理開始]
+    ProcessDual --> Concurrent
+
+    Concurrent --> ProcessFile1[ファイル1を処理]
+    Concurrent --> ProcessFile2[ファイル2を処理]
+    Concurrent --> ProcessFileN[ファイルNを処理]
+
+    ProcessFile1 --> Collect[結果を集計]
+    ProcessFile2 --> Collect
+    ProcessFileN --> Collect
+
+    Collect --> PrintStats[統計情報表示]
+    PrintStats --> CheckFollow{フォローモード?}
+
+    CheckFollow -->|Yes| Wait[次のサイクルまで待機]
+    CheckFollow -->|No| End([完了])
+
+    Wait --> FollowLoop
+
+    style Start fill:#e1f5ff
+    style End fill:#e1ffe1
+    style ProcessFile1 fill:#fff4e1
+    style ProcessFile2 fill:#fff4e1
+    style ProcessFileN fill:#fff4e1
+```
+
+## 1ファイルの詳細処理フロー
+
+```mermaid
+graph TB
+    FileStart([Markdownファイル]) --> CheckContent{コンテンツ<br/>読み込み済み?}
+
+    CheckContent -->|No| ReadFile[ファイル内容を読み込み]
+    CheckContent -->|Yes| ExtractMeta
+
+    ReadFile --> ExtractMeta[メタデータ抽出]
+
+    ExtractMeta --> ParseFM[Front Matter解析]
+    ParseFM --> ExtractTitle[タイトル抽出]
+    ExtractTitle --> ExtractCategory[カテゴリ抽出]
+    ExtractCategory --> ExtractTags[タグ抽出]
+    ExtractTags --> ExtractAuthor[著者抽出]
+    ExtractAuthor --> ExtractDates[日付抽出]
+    ExtractDates --> CalcWords[単語数カウント]
+
+    CalcWords --> CheckDryRun{Dry Run<br/>モード?}
+
+    CheckDryRun -->|Yes| LogDryRun[処理内容をログ出力]
+    CheckDryRun -->|No| GenerateEmbed[埋め込みベクトル生成]
+
+    LogDryRun --> DryRunEnd([Dry Run完了])
+
+    GenerateEmbed --> PrepareRequest[Bedrock APIリクエスト準備]
+    PrepareRequest --> InvokeBedrock[Titan v2モデル呼び出し]
+    InvokeBedrock --> ParseResponse[レスポンス解析]
+    ParseResponse --> ValidateEmbed{ベクトル検証}
+
+    ValidateEmbed -->|空| EmbedError([エラー: 空のベクトル])
+    ValidateEmbed -->|正常| CreateVector[VectorData作成]
+
+    CreateVector --> PrepareMetadata[S3用メタデータ準備]
+    PrepareMetadata --> TruncateExcerpt[コンテンツ抜粋を作成<br/>512バイト制限]
+    TruncateExcerpt --> ConvertFloat32[float64→float32変換]
+    ConvertFloat32 --> StoreS3[S3 Vectorsに保存]
+
+    StoreS3 --> CheckOpenSearch{OpenSearch<br/>有効?}
+
+    CheckOpenSearch -->|Yes| IndexOpenSearch[OpenSearchにインデックス]
+    CheckOpenSearch -->|No| Success([処理完了])
+
+    IndexOpenSearch --> Success
+
+    style FileStart fill:#e1f5ff
+    style Success fill:#e1ffe1
+    style DryRunEnd fill:#ffe1e1
+    style EmbedError fill:#ffe1e1
+    style GenerateEmbed fill:#fff4e1
+    style StoreS3 fill:#fff4e1
+    style IndexOpenSearch fill:#fff4e1
+```
+
+## 各ステップの詳細説明
+
+### 1. ファイルスキャン (`FileScanner.ScanDirectory`)
+
+**処理内容:**
+- 指定されたディレクトリを再帰的に探索
+- `.md` 拡張子のファイルを検出
+- ファイル情報（パス、サイズ、更新日時）を収集
+
+**コード例:**
+```go
+files, err := vs.fileScanner.ScanDirectory(directory)
+// 例: markdown/tech/ai/machine-learning.md を検出
+```
+
+**出力:**
+```
+Found 150 markdown files to process
+```
+
+### 2. メタデータ抽出 (`MetadataExtractor.ExtractMetadata`)
+
+**処理内容:**
+- Markdownファイルの先頭にあるYAML形式のFront Matterを解析
+- タイトル、カテゴリ、タグ、著者などを抽出
+- 単語数をカウント
+
+**Front Matter の例:**
+```yaml
+---
+title: "機械学習の基礎"
+category: "技術ドキュメント"
+tags: ["AI", "機械学習", "Python"]
+author: "山田太郎"
+created_at: "2024-01-15"
+---
+```
+
+**抽出されるメタデータ:**
+```go
+DocumentMetadata{
+    Title:      "機械学習の基礎",
+    Category:   "技術ドキュメント",
+    Tags:       ["AI", "機械学習", "Python"],
+    Author:     "山田太郎",
+    FilePath:   "markdown/tech/ai/machine-learning.md",
+    Source:     "machine-learning.md",
+    WordCount:  1250,
+    CreatedAt:  "2024-01-15T00:00:00Z",
+}
+```
+
+### 3. 埋め込みベクトル生成 (`BedrockClient.GenerateEmbedding`)
+
+**処理内容:**
+- Markdownの本文全体をAmazon Bedrockに送信
+- Titan Text Embedding v2 モデルを使用
+- 1024次元のベクトルを生成
+- コサイン類似度で検索するため正規化
+
+**技術仕様:**
+- **モデル:** `amazon.titan-embed-text-v2:0`
+- **次元数:** 1024
+- **正規化:** 有効（normalize: true）
+- **最大入力トークン数:** 8,192トークン
+
+**APIリクエスト例:**
+```json
+{
+  "inputText": "# 機械学習の基礎\n\n機械学習は...",
+  "dimensions": 1024,
+  "normalize": true
+}
+```
+
+**APIレスポンス例:**
+```json
+{
+  "embedding": [0.0234, -0.1456, 0.0789, ..., 0.0345],
+  "inputTextTokenCount": 1523
+}
+```
+
+**生成されるベクトル:**
+- 長さ: 1024個の浮動小数点数
+- 範囲: -1.0 〜 1.0（正規化済み）
+- 例: `[0.0234, -0.1456, 0.0789, ..., 0.0345]`
+
+### 4. S3 Vectors保存 (`S3VectorService.StoreVector`)
+
+**処理内容:**
+- ベクトルとメタデータをAmazon S3 Vectorsに保存
+- メタデータは2048バイト制限のため、本文は512バイトの抜粋のみ保存
+- float64からfloat32に変換（S3 Vectors要件）
+
+**保存されるデータ構造:**
+```go
+PutVectorsInput{
+    VectorBucketName: "my-vector-bucket",
+    IndexName:        "document-vectors",
+    Vectors: [
+        {
+            Key: "tech/ai/machine-learning.md",
+            Data: [float32配列: 1024次元],
+            Metadata: {
+                "title":           "機械学習の基礎",
+                "category":        "技術ドキュメント",
+                "file_path":       "markdown/tech/ai/machine-learning.md",
+                "word_count":      1250,
+                "content_excerpt": "機械学習は、データから...",
+                "tags":            ["AI", "機械学習", "Python"],
+                "author":          "山田太郎",
+                "created_at":      "2024-01-15T00:00:00Z",
+            }
+        }
+    ]
+}
+```
+
+**メタデータ制限対応:**
+- 合計サイズ制限: 2048バイト
+- 本文抜粋: 最大512バイト（UTF-8で安全に切り詰め）
+- カスタムフィールドも含めて保存
+
+### 5. OpenSearchインデックス作成（オプション）
+
+**処理内容:**
+- デュアルバックエンドモード時に実行
+- BM25検索用の転置インデックス作成
+- k-NN検索用のベクトルインデックス作成
+- 日本語対応（kuromojiトークナイザー）
+
+**インデックス設定:**
+```json
+{
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "japanese": {
+          "type": "custom",
+          "tokenizer": "kuromoji_tokenizer"
+        }
+      }
+    },
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "content": {
+        "type": "text",
+        "analyzer": "japanese"
+      },
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 1024,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss"
+        }
+      }
+    }
+  }
+}
+```
+
+## 並行処理とエラーハンドリング
+
+### 並行処理の仕組み
+
+RAGentは、複数のファイルを同時に処理することで高速化を実現しています。
+
+**並行処理フロー:**
+```mermaid
+graph LR
+    Files[150個のファイル] --> Worker1[Worker 1]
+    Files --> Worker2[Worker 2]
+    Files --> Worker3[Worker 3]
+    Files --> WorkerN[Worker N]
+
+    Worker1 --> Bedrock[Amazon Bedrock]
+    Worker2 --> Bedrock
+    Worker3 --> Bedrock
+    WorkerN --> Bedrock
+
+    Bedrock --> S3[S3 Vectors]
+
+    style Files fill:#e1f5ff
+    style Bedrock fill:#fff4e1
+    style S3 fill:#e1ffe1
+```
+
+**設定:**
+- デフォルト並行数: 5
+- カスタマイズ: `--concurrency` フラグで指定可能
+- レート制限対応: `golang.org/x/time/rate` で制御
+
+### エラーハンドリング
+
+各ステップで発生しうるエラーと対処:
+
+| エラータイプ | 原因 | 対処 |
+|-------------|------|------|
+| `ErrorTypeFileRead` | ファイル読み込み失敗 | ファイルパスとパーミッション確認 |
+| `ErrorTypeMetadata` | メタデータ解析失敗 | Front Matter形式を確認 |
+| `ErrorTypeEmbedding` | ベクトル生成失敗 | Bedrock API接続とクォータ確認 |
+| `ErrorTypeS3Upload` | S3保存失敗 | AWS認証情報とバケット権限確認 |
+
+**ログ出力例:**
+```
+INFO: Generating embedding for file: markdown/tech/ai/machine-learning.md
+INFO: Successfully generated embedding with 1024 dimensions
+INFO: Storing vector to S3 Vectors with key: tech/ai/machine-learning.md
+SUCCESS: Processed 1/150 files
+```
+
+## Dry Runモード
+
+実際にベクトル化を実行せず、処理内容を確認できます。
+
+**使用方法:**
+```bash
+./RAGent vectorize --directory ./markdown --dry-run
+```
+
+**出力例:**
+```
+DRY RUN: Would process file markdown/tech/ai/machine-learning.md
+  - Title: 機械学習の基礎
+  - Category: 技術ドキュメント
+  - Word count: 1250
+  - Would generate 1024-dimensional embedding
+  - Would store to S3 Vectors
+```
+
+## フォローモード
+
+継続的にディレクトリを監視し、定期的にベクトル化を実行します。
+
+**使用方法:**
+```bash
+# デフォルト30分間隔
+./RAGent vectorize --follow
+
+# カスタム間隔（15分）
+./RAGent vectorize --follow --interval 15m
+```
+
+**動作:**
+```mermaid
+graph LR
+    Scan1[スキャン] --> Process1[処理]
+    Process1 --> Wait1[30分待機]
+    Wait1 --> Scan2[スキャン]
+    Scan2 --> Process2[処理]
+    Process2 --> Wait2[30分待機]
+    Wait2 --> Loop[...]
+
+    style Scan1 fill:#e1f5ff
+    style Scan2 fill:#e1f5ff
+    style Process1 fill:#fff4e1
+    style Process2 fill:#fff4e1
+```
+
+**終了方法:**
+- `Ctrl+C` でグレースフルシャットダウン
+- 処理中のファイルは完了してから終了
+
+## 処理統計
+
+処理完了後、以下の統計情報が表示されます:
+
+```
+Vectorization completed successfully!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Processing Statistics:
+  Total Files:      150
+  Successful:       148
+  Failed:           2
+  Skipped:          0
+  Processing Time:  5m 23s
+  Avg Time/File:    2.16s
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Failed files:
+  1. markdown/draft/incomplete.md
+     Error: failed to parse front matter
+  2. markdown/temp/test.md
+     Error: empty embedding returned
+```
+
+## 技術仕様まとめ
+
+### ベクトル仕様
+- **モデル:** Amazon Titan Text Embedding v2
+- **次元数:** 1024
+- **距離メトリック:** コサイン距離
+- **正規化:** 有効
+
+### ストレージ仕様
+- **S3 Vectors:**
+  - メタデータ制限: 2048バイト
+  - ベクトル形式: float32
+  - インデックス: 自動作成
+
+- **OpenSearch（オプション）:**
+  - BM25インデックス: 日本語最適化
+  - k-NNインデックス: HNSW + FAISS
+  - 推奨検索件数: Dense@100 + BM25@200
+
+### パフォーマンス
+- **並行処理:** デフォルト5並行
+- **スループット:** 約30ファイル/分（1000文字/ファイル）
+- **Bedrockクォータ:** 1分あたり100リクエスト（東京リージョン）
+
+## 使用例
+
+### 基本的な使用
+
+```bash
+# 1. 初回ベクトル化
+./RAGent vectorize --directory ./markdown
+
+# 2. Dry Runで確認
+./RAGent vectorize --directory ./markdown --dry-run
+
+# 3. 並行数を調整
+./RAGent vectorize --directory ./markdown --concurrency 10
+```
+
+### デュアルバックエンドモード
+
+```bash
+# S3 Vector + OpenSearch
+export OPENSEARCH_ENDPOINT="https://search-xxx.ap-northeast-1.es.amazonaws.com"
+./RAGent vectorize --directory ./markdown --opensearch-index documents
+```
+
+### フォローモード
+
+```bash
+# 継続的な更新監視（30分間隔）
+./RAGent vectorize --follow
+
+# カスタム間隔（15分）
+./RAGent vectorize --follow --interval 15m
+
+# バックグラウンド実行
+nohup ./RAGent vectorize --follow > vectorize.log 2>&1 &
+```
+
+### ベクトルのクリア
+
+```bash
+# 既存ベクトルを全削除してから再ベクトル化
+./RAGent vectorize --directory ./markdown --clear
+```
+
+**警告:** `--clear` は全ベクトルを削除します。実行前に確認プロンプトが表示されます。
+
+## トラブルシューティング
+
+### よくあるエラーと解決方法
+
+**1. "failed to invoke bedrock model: AccessDeniedException"**
+```bash
+# AWS認証情報を確認
+aws configure list
+
+# Bedrock APIのアクセス権限を確認
+aws bedrock list-foundation-models --region ap-northeast-1
+```
+
+**2. "failed to upload vector to S3 Vectors: NoSuchBucket"**
+```bash
+# S3バケットの存在確認
+aws s3 ls s3://${S3_BUCKET_NAME}
+
+# S3 Vectorsインデックスの確認
+aws s3vectors list-vector-indexes --bucket-name ${S3_BUCKET_NAME}
+```
+
+**3. "empty embedding returned"**
+- ファイルが空または短すぎる
+- 最小200文字以上を推奨
+
+**4. "metadata exceeds 2048 bytes"**
+- Front Matterのカスタムフィールドが多すぎる
+- 不要なフィールドを削除
+
+## 関連コマンド
+
+ベクトル化後の利用:
+
+```bash
+# 1. ベクトル一覧表示
+./RAGent list
+
+# 2. セマンティック検索
+./RAGent query -q "機械学習のアルゴリズム" --search-mode hybrid
+
+# 3. 対話的RAGチャット
+./RAGent chat
+
+# 4. Slack Bot起動
+./RAGent slack-bot
+
+# 5. MCP Server起動
+./RAGent mcp-server
+```
+
+## まとめ
+
+`vectorize` コマンドは、以下の処理を自動的に実行します:
+
+1. ✅ Markdownファイルの発見とスキャン
+2. ✅ Front Matterからメタデータ抽出
+3. ✅ Amazon Bedrockで1024次元ベクトル生成
+4. ✅ S3 Vectorsに保存（検索可能な形式）
+5. ✅ OpenSearchにインデックス作成（オプション）
+
+これにより、テキストドキュメントがセマンティック検索可能なベクトルデータベースに変換され、高精度なRAG検索が可能になります。
+
+## 次のステップ
+
+- [query.md](./query.md) - ハイブリッド検索の仕組み（作成予定）
+- [chat.md](./chat.md) - 対話的RAGの使い方（作成予定）
+- [opensearch.md](./opensearch.md) - OpenSearch統合の詳細（作成予定）

--- a/internal/opensearch/bm25_test.go
+++ b/internal/opensearch/bm25_test.go
@@ -1,0 +1,89 @@
+package opensearch
+
+import "testing"
+
+func TestBuildBM25SearchBodyAddsPhraseShouldClause(t *testing.T) {
+	client := &Client{}
+	query := &BM25Query{
+		Query:  "0円チャージ",
+		Fields: []string{"title", "content"},
+		Size:   10,
+	}
+
+	body := client.buildBM25SearchBody(query)
+	querySection, ok := body["query"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("query section missing")
+	}
+
+	boolQuery, ok := querySection["bool"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("bool query missing")
+	}
+
+	shouldClause, ok := boolQuery["should"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected should clause to be added")
+	}
+
+	if len(shouldClause) == 0 {
+		t.Fatalf("should clause should contain at least one element")
+	}
+
+	phraseFound := false
+	for _, clause := range shouldClause {
+		multiMatch, ok := clause["multi_match"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		typeValue, _ := multiMatch["type"].(string)
+		if typeValue != "phrase" {
+			continue
+		}
+
+		if boost, ok := multiMatch["boost"].(float64); !ok || boost != phraseMatchBoost {
+			continue
+		}
+
+		if q, _ := multiMatch["query"].(string); q == query.Query {
+			phraseFound = true
+			break
+		}
+	}
+
+	if !phraseFound {
+		t.Fatalf("expected multi_match phrase clause to be present")
+	}
+}
+
+func TestBuildMatchPhraseQuerySingleFieldUsesMatchPhrase(t *testing.T) {
+	client := &Client{}
+	query := &BM25Query{
+		Query:  "0円チャージ",
+		Fields: []string{"content"},
+	}
+
+	clause := client.buildMatchPhraseQuery(query)
+	if clause == nil {
+		t.Fatalf("expected clause to be generated")
+	}
+
+	matchPhrase, ok := clause["match_phrase"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected match_phrase clause")
+	}
+
+	fieldClause, ok := matchPhrase[query.Fields[0]].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected single field clause")
+	}
+
+	if q, _ := fieldClause["query"].(string); q != query.Query {
+		t.Fatalf("expected query to match, got %s", q)
+	}
+
+	if boost, _ := fieldClause["boost"].(float64); boost != phraseMatchBoost {
+		t.Fatalf("expected boost %.1f, got %v", phraseMatchBoost, boost)
+	}
+}

--- a/internal/opensearch/hybrid_engine.go
+++ b/internal/opensearch/hybrid_engine.go
@@ -4,18 +4,37 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
+	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
-	"github.com/ca-srg/ragent/internal/embedding/bedrock"
 	"golang.org/x/sync/errgroup"
 )
 
+type SearchClient interface {
+	SearchTermQuery(ctx context.Context, indexName string, query *TermQuery) (*TermQueryResponse, error)
+	SearchBM25(ctx context.Context, indexName string, query *BM25Query) (*BM25SearchResponse, error)
+	SearchDenseVector(ctx context.Context, indexName string, query *VectorQuery) (*VectorSearchResponse, error)
+	RecordRequest(duration time.Duration, success bool)
+	GetMetrics() *PerformanceMetrics
+	LogMetrics()
+}
+
+type EmbeddingClient interface {
+	GenerateEmbedding(ctx context.Context, text string) ([]float64, error)
+}
+
 type HybridSearchEngine struct {
-	client          *Client
-	embeddingClient *bedrock.BedrockClient
+	client          SearchClient
+	embeddingClient EmbeddingClient
 	textProcessor   *JapaneseTextProcessor
 	fusionEngine    *FusionEngine
+	urlDetector     URLDetector
 }
+
+var digitPhrasePattern = regexp.MustCompile(`[0-9０-９]+(?:円|％|%|[\p{Han}\p{Katakana}ーA-Za-z0-9０-９])+`)
 
 type HybridQuery struct {
 	Query                  string            `json:"query"`
@@ -50,14 +69,19 @@ type HybridSearchResult struct {
 	FusionTime     time.Duration         `json:"fusion_time"`
 	Errors         []string              `json:"errors,omitempty"`
 	PartialResults bool                  `json:"partial_results"`
+	SearchMethod   string                `json:"search_method"`
+	URLDetected    bool                  `json:"url_detected"`
+	TermQueryTime  time.Duration         `json:"term_query_time,omitempty"`
+	FallbackReason string                `json:"fallback_reason,omitempty"`
 }
 
-func NewHybridSearchEngine(client *Client, embeddingClient *bedrock.BedrockClient) *HybridSearchEngine {
+func NewHybridSearchEngine(client SearchClient, embeddingClient EmbeddingClient) *HybridSearchEngine {
 	return &HybridSearchEngine{
 		client:          client,
 		embeddingClient: embeddingClient,
 		textProcessor:   NewJapaneseTextProcessor(),
 		fusionEngine:    NewFusionEngine(60.0),
+		urlDetector:     NewURLDetector(),
 	}
 }
 
@@ -79,6 +103,8 @@ func (hse *HybridSearchEngine) Search(ctx context.Context, query *HybridQuery) (
 
 	result := &HybridSearchResult{
 		PartialResults: false,
+		SearchMethod:   "hybrid_search",
+		URLDetected:    false,
 	}
 
 	var processedQuery *ProcessedQuery
@@ -87,6 +113,68 @@ func (hse *HybridSearchEngine) Search(ctx context.Context, query *HybridQuery) (
 		result.ProcessedQuery = processedQuery
 	}
 
+	detector := hse.urlDetector
+	if detector == nil {
+		detector = NewURLDetector()
+		hse.urlDetector = detector
+	}
+
+	urlDetected := false
+	termQueryDuration := time.Duration(0)
+	fallbackReason := ""
+
+	if detector != nil {
+		detectionResult := detector.DetectURLs(query.Query)
+		if detectionResult != nil && detectionResult.HasURL {
+			log.Printf("URL detected in query: %v", detectionResult.URLs)
+			urlDetected = true
+			termQuery := &TermQuery{
+				Field:  "reference",
+				Values: detectionResult.URLs,
+				Size:   query.Size,
+			}
+			if termQuery.Size <= 0 {
+				termQuery.Size = len(detectionResult.URLs)
+			}
+
+			log.Printf("Executing term query on 'reference' field for %d URL(s)", len(detectionResult.URLs))
+			termStart := time.Now()
+			termResponse, err := hse.client.SearchTermQuery(ctx, query.IndexName, termQuery)
+			termQueryDuration = time.Since(termStart)
+
+			if err == nil && termResponse != nil && termResponse.TotalHits > 0 {
+				log.Printf("Term query found %d result(s) in %v", termResponse.TotalHits, termQueryDuration)
+				result.FusionResult = hse.buildExactMatchFusionResult(termResponse)
+				result.ExecutionTime = time.Since(startTime)
+				result.SearchMethod = "url_exact_match"
+				result.URLDetected = true
+				result.TermQueryTime = termQueryDuration
+				result.FallbackReason = ""
+				hse.client.RecordRequest(result.ExecutionTime, true)
+				log.Printf("Returning URL exact match with %d result(s) in %v", termResponse.TotalHits, termQueryDuration)
+				return result, nil
+			}
+
+			if err != nil {
+				log.Printf("Term query failed after %v: %v", termQueryDuration, err)
+				result.Errors = append(result.Errors, fmt.Sprintf("Term query failed: %v", err))
+				fallbackReason = "term_query_error"
+			} else {
+				log.Printf("Term query returned no results after %v", termQueryDuration)
+				fallbackReason = "term_query_no_results"
+			}
+			if fallbackReason != "" {
+				log.Printf("Falling back to hybrid search: %s", fallbackReason)
+			}
+		} else {
+			log.Printf("No URL detected in query")
+		}
+	}
+
+	return hse.performHybridSearch(ctx, query, processedQuery, result, startTime, urlDetected, termQueryDuration, fallbackReason)
+}
+
+func (hse *HybridSearchEngine) performHybridSearch(ctx context.Context, query *HybridQuery, processedQuery *ProcessedQuery, result *HybridSearchResult, startTime time.Time, urlDetected bool, termQueryDuration time.Duration, fallbackReason string) (*HybridSearchResult, error) {
 	var bm25Response *BM25SearchResponse
 	var vectorResponse *VectorSearchResponse
 	var embeddingVector []float64
@@ -176,12 +264,14 @@ func (hse *HybridSearchEngine) Search(ctx context.Context, query *HybridQuery) (
 	result.BM25Response = bm25Response
 	result.VectorResponse = vectorResponse
 	result.ExecutionTime = time.Since(startTime)
+	result.SearchMethod = "hybrid_search"
+	result.URLDetected = urlDetected
+	result.TermQueryTime = termQueryDuration
+	result.FallbackReason = fallbackReason
 
-	// Record performance metrics
 	hse.client.RecordRequest(result.ExecutionTime, true)
 
-	// Log detailed performance metrics
-	log.Printf("Hybrid search completed successfully in %v", result.ExecutionTime)
+	log.Printf("Search completed: method=%s, results=%d, time=%v", result.SearchMethod, fusionResult.TotalHits, result.ExecutionTime)
 	log.Printf("Performance breakdown - BM25: %v, Vector: %v, Embedding: %v, Fusion: %v",
 		result.BM25Time, result.VectorTime, result.EmbeddingTime, result.FusionTime)
 	log.Printf("Results summary - Total: %d, BM25: %d, Vector: %d, Fusion: %s",
@@ -191,12 +281,45 @@ func (hse *HybridSearchEngine) Search(ctx context.Context, query *HybridQuery) (
 		log.Printf("Search completed with %d warnings: %v", len(result.Errors), result.Errors)
 	}
 
-	// Log OpenSearch client metrics every 10th request
 	if hse.client.GetMetrics().RequestCount%10 == 0 {
 		hse.client.LogMetrics()
 	}
 
 	return result, nil
+}
+
+func (hse *HybridSearchEngine) buildExactMatchFusionResult(termResponse *TermQueryResponse) *FusionResult {
+	if termResponse == nil {
+		return nil
+	}
+
+	documents := make([]ScoredDoc, len(termResponse.Results))
+	var maxScore float64
+
+	for i, hit := range termResponse.Results {
+		score := hit.Score
+		documents[i] = ScoredDoc{
+			ID:         hit.ID,
+			Score:      score,
+			FusedScore: score,
+			Source:     hit.Source,
+			Index:      hit.Index,
+			Rank:       i + 1,
+			SearchType: "url_exact_match",
+		}
+		if score > maxScore {
+			maxScore = score
+		}
+	}
+
+	return &FusionResult{
+		Documents:     documents,
+		TotalHits:     termResponse.TotalHits,
+		MaxScore:      maxScore,
+		BM25Results:   0,
+		VectorResults: 0,
+		FusionType:    "url_exact_match",
+	}
 }
 
 func (hse *HybridSearchEngine) validateQuery(query *HybridQuery) error {
@@ -267,14 +390,33 @@ func (hse *HybridSearchEngine) buildBM25Query(query *HybridQuery, processedQuery
 		operator = query.BM25Operator
 	}
 
+	minimumShouldMatch := query.BM25MinimumShouldMatch
+	if minimumShouldMatch == "" && shouldEnforceExactMatch(searchQuery) {
+		minimumShouldMatch = "100%"
+		log.Printf("Enforcing minimum_should_match=100%% for digit-heavy query: original=%q normalized=%q", query.Query, searchQuery)
+	}
+
+	boostPhrases := extractCriticalPhrases(query.Query)
+	if processedQuery != nil && processedQuery.Normalized != "" {
+		for _, phrase := range extractCriticalPhrases(processedQuery.Normalized) {
+			if !containsString(boostPhrases, phrase) {
+				boostPhrases = append(boostPhrases, phrase)
+			}
+		}
+	}
+	if len(boostPhrases) > 0 {
+		log.Printf("Adding boosted phrase clauses for: %v", boostPhrases)
+	}
+
 	return &BM25Query{
 		Query:              searchQuery,
 		Fields:             query.Fields,
 		Operator:           operator,
-		MinimumShouldMatch: query.BM25MinimumShouldMatch,
+		MinimumShouldMatch: minimumShouldMatch,
 		Filters:            query.Filters,
 		Size:               query.K,
 		From:               query.From,
+		BoostPhrases:       boostPhrases,
 	}
 }
 
@@ -289,6 +431,101 @@ func (hse *HybridSearchEngine) buildVectorQuery(query *HybridQuery, vector []flo
 		Size:        query.Size,
 		From:        query.From,
 	}
+}
+
+func shouldEnforceExactMatch(query string) bool {
+	trimmed := strings.TrimSpace(query)
+	if trimmed == "" {
+		return false
+	}
+
+	if utf8.RuneCountInString(trimmed) > 24 {
+		return false
+	}
+
+	tokens := strings.Fields(trimmed)
+	if len(tokens) > 4 {
+		return false
+	}
+
+	hasDigit := false
+	hasCurrency := false
+
+	for _, r := range trimmed {
+		if unicode.IsDigit(r) {
+			hasDigit = true
+			continue
+		}
+		switch r {
+		case '円', '圓', '¥', '￥', '%', '％':
+			hasCurrency = true
+		}
+	}
+
+	return hasDigit && (hasCurrency || len(tokens) <= 2)
+}
+
+func extractCriticalPhrases(original string) []string {
+	stripped := strings.TrimSpace(original)
+	if stripped == "" {
+		return nil
+	}
+
+	// Normalize by removing spaces so patterns like "0 円" are captured
+	cleaned := strings.ReplaceAll(stripped, " ", "")
+	cleaned = strings.ReplaceAll(cleaned, "　", "")
+
+	matches := digitPhrasePattern.FindAllString(cleaned, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(matches))
+	phrases := make([]string, 0, len(matches))
+	for _, m := range matches {
+		candidate := strings.TrimSpace(m)
+		if candidate == "" {
+			continue
+		}
+
+		runeLen := utf8.RuneCountInString(candidate)
+		if runeLen < 3 {
+			continue
+		}
+		if runeLen > 16 {
+			continue
+		}
+		if strings.ContainsAny(candidate, ":/.@><") {
+			continue
+		}
+
+		hasNonDigit := false
+		for _, r := range candidate {
+			if !unicode.IsDigit(r) {
+				hasNonDigit = true
+				break
+			}
+		}
+		if !hasNonDigit {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		phrases = append(phrases, candidate)
+	}
+
+	return phrases
+}
+
+func containsString(slice []string, target string) bool {
+	for _, v := range slice {
+		if v == target {
+			return true
+		}
+	}
+	return false
 }
 
 func (hse *HybridSearchEngine) SearchBM25Only(ctx context.Context, query *HybridQuery) (*HybridSearchResult, error) {

--- a/internal/opensearch/hybrid_engine_test.go
+++ b/internal/opensearch/hybrid_engine_test.go
@@ -1,0 +1,101 @@
+package opensearch
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestBuildBM25QueryEnforcesExactMatchAndLogs(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.Default()
+	originalWriter := logger.Writer()
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(originalWriter)
+
+	hse := &HybridSearchEngine{
+		textProcessor: NewJapaneseTextProcessor(),
+	}
+
+	hybridQuery := &HybridQuery{
+		Query:  "0円チャージ",
+		Fields: []string{"title"},
+		K:      10,
+	}
+
+	bm25Query := hse.buildBM25Query(hybridQuery, nil)
+
+	if bm25Query.MinimumShouldMatch != "100%" {
+		t.Fatalf("expected minimum_should_match to be 100%%, got %s", bm25Query.MinimumShouldMatch)
+	}
+
+	if len(bm25Query.BoostPhrases) != 1 || bm25Query.BoostPhrases[0] != "0円チャージ" {
+		t.Fatalf("expected boost phrases [0円チャージ], got %v", bm25Query.BoostPhrases)
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "minimum_should_match=100%") {
+		t.Fatalf("expected log to contain enforcement message, got %q", logOutput)
+	}
+	if !strings.Contains(logOutput, "0円チャージ") {
+		t.Fatalf("expected log to include original query, got %q", logOutput)
+	}
+	if !strings.Contains(logOutput, "Adding boosted phrase clauses") {
+		t.Fatalf("expected log to mention boosted phrase clauses, got %q", logOutput)
+	}
+}
+
+func TestBuildBM25QueryDoesNotEnforceForLongQuery(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.Default()
+	originalWriter := logger.Writer()
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(originalWriter)
+
+	hse := &HybridSearchEngine{
+		textProcessor: NewJapaneseTextProcessor(),
+	}
+
+	hybridQuery := &HybridQuery{
+		Query:  "チャージに関するキャンペーンの仕様を確認したい",
+		Fields: []string{"content"},
+		K:      10,
+	}
+
+	bm25Query := hse.buildBM25Query(hybridQuery, nil)
+
+	if bm25Query.MinimumShouldMatch != "" {
+		t.Fatalf("expected minimum_should_match to remain empty, got %s", bm25Query.MinimumShouldMatch)
+	}
+
+	if len(bm25Query.BoostPhrases) != 0 {
+		t.Fatalf("expected no boost phrases, got %v", bm25Query.BoostPhrases)
+	}
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no enforcement log, got %q", buf.String())
+	}
+}
+
+func TestBuildBM25QueryExtractsBoostPhraseFromLongQuery(t *testing.T) {
+	hse := &HybridSearchEngine{
+		textProcessor: NewJapaneseTextProcessor(),
+	}
+
+	hybridQuery := &HybridQuery{
+		Query:  "0円チャージに関する記事をピックアップしてください",
+		Fields: []string{"content", "title"},
+		K:      10,
+	}
+
+	bm25Query := hse.buildBM25Query(hybridQuery, nil)
+
+	if bm25Query.MinimumShouldMatch != "" {
+		t.Fatalf("expected minimum_should_match to stay empty for long query, got %s", bm25Query.MinimumShouldMatch)
+	}
+
+	if len(bm25Query.BoostPhrases) != 1 || bm25Query.BoostPhrases[0] != "0円チャージ" {
+		t.Fatalf("expected boost phrases [0円チャージ], got %v", bm25Query.BoostPhrases)
+	}
+}

--- a/internal/opensearch/term_query.go
+++ b/internal/opensearch/term_query.go
@@ -1,0 +1,27 @@
+package opensearch
+
+import "encoding/json"
+
+// TermQuery represents the parameters for executing an OpenSearch term query.
+type TermQuery struct {
+	Field  string   `json:"field"`
+	Values []string `json:"values"`
+	Size   int      `json:"size,omitempty"`
+	From   int      `json:"from,omitempty"`
+}
+
+// TermQueryResult captures a single OpenSearch hit returned from a term query.
+type TermQueryResult struct {
+	Index  string          `json:"_index"`
+	ID     string          `json:"_id"`
+	Score  float64         `json:"_score"`
+	Source json.RawMessage `json:"_source"`
+}
+
+// TermQueryResponse provides a simplified view over the OpenSearch term query response.
+type TermQueryResponse struct {
+	Took      int               `json:"took"`
+	TimedOut  bool              `json:"timed_out"`
+	TotalHits int               `json:"total_hits"`
+	Results   []TermQueryResult `json:"results"`
+}

--- a/internal/opensearch/url_detector.go
+++ b/internal/opensearch/url_detector.go
@@ -1,0 +1,59 @@
+package opensearch
+
+import (
+	"regexp"
+	"strings"
+)
+
+// URLDetectorはクエリ文字列からHTTP/HTTPS URLを抽出するインターフェース。
+type URLDetector interface {
+	DetectURLs(query string) *URLDetectionResult
+}
+
+// URLDetectionResultは検出結果を表す。
+type URLDetectionResult struct {
+	HasURL        bool
+	URLs          []string
+	OriginalQuery string
+}
+
+type defaultURLDetector struct {
+	urlPattern *regexp.Regexp
+}
+
+var defaultURLPattern = regexp.MustCompile(`(?i)https?://[^\s\p{Zs}]+`)
+
+// NewURLDetectorはデフォルト実装を返す。
+func NewURLDetector() URLDetector {
+	return &defaultURLDetector{urlPattern: defaultURLPattern}
+}
+
+// DetectURLsはクエリからURLを検出して結果を返す。
+func (d *defaultURLDetector) DetectURLs(query string) *URLDetectionResult {
+	result := &URLDetectionResult{OriginalQuery: query}
+
+	trimmed := strings.TrimSpace(query)
+	if trimmed == "" {
+		return result
+	}
+
+	matches := d.urlPattern.FindAllString(trimmed, -1)
+	if len(matches) == 0 {
+		return result
+	}
+
+	seen := make(map[string]struct{}, len(matches))
+	for _, url := range matches {
+		if _, ok := seen[url]; ok {
+			continue
+		}
+		seen[url] = struct{}{}
+		result.URLs = append(result.URLs, url)
+	}
+
+	if len(result.URLs) > 0 {
+		result.HasURL = true
+	}
+
+	return result
+}

--- a/internal/search/hybrid_service.go
+++ b/internal/search/hybrid_service.go
@@ -39,6 +39,7 @@ type SearchResponse struct {
 	TotalResults int               `json:"total_results"`
 	SearchTime   string            `json:"search_time"`
 	IndexUsed    string            `json:"index_used"`
+	SearchMethod string            `json:"search_method"`
 }
 
 // NewHybridSearchService creates a new hybrid search service
@@ -146,6 +147,7 @@ func (s *HybridSearchService) Search(ctx context.Context, request *SearchRequest
 		TotalResults: result.FusionResult.TotalHits,
 		SearchTime:   result.ExecutionTime.String(),
 		IndexUsed:    request.IndexName,
+		SearchMethod: result.SearchMethod,
 	}
 
 	for _, doc := range result.FusionResult.Documents {

--- a/internal/slackbot/search_adapter.go
+++ b/internal/slackbot/search_adapter.go
@@ -146,5 +146,8 @@ func (h *HybridSearchAdapter) Search(ctx context.Context, query string) *SearchR
 		GeneratedResponse: generatedResponse,
 		Total:             len(res.FusionResult.Documents),
 		Elapsed:           time.Since(start),
+		SearchMethod:      res.SearchMethod,
+		URLDetected:       res.URLDetected,
+		FallbackReason:    res.FallbackReason,
 	}
 }

--- a/internal/types/mcp_types.go
+++ b/internal/types/mcp_types.go
@@ -87,11 +87,14 @@ type HybridSearchRequest struct {
 
 // HybridSearchResponse represents the hybrid search tool response
 type HybridSearchResponse struct {
-	Query      string                   `json:"query"`
-	Total      int                      `json:"total"`
-	SearchMode string                   `json:"search_mode"`
-	Results    []HybridSearchResultItem `json:"results"`
-	Metadata   *HybridSearchMetadata    `json:"metadata,omitempty"`
+	Query          string                   `json:"query"`
+	Total          int                      `json:"total"`
+	SearchMode     string                   `json:"search_mode"`
+	SearchMethod   string                   `json:"search_method"`
+	URLDetected    bool                     `json:"url_detected,omitempty"`
+	FallbackReason string                   `json:"fallback_reason,omitempty"`
+	Results        []HybridSearchResultItem `json:"results"`
+	Metadata       *HybridSearchMetadata    `json:"metadata,omitempty"`
 }
 
 // HybridSearchResultItem represents a single search result

--- a/tests/benchmark/url_aware_search_bench_test.go
+++ b/tests/benchmark/url_aware_search_bench_test.go
@@ -1,0 +1,243 @@
+package benchmark
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ca-srg/ragent/internal/opensearch"
+)
+
+type benchStubEmbeddingClient struct {
+	vector []float64
+}
+
+func (s *benchStubEmbeddingClient) GenerateEmbedding(context.Context, string) ([]float64, error) {
+	return append([]float64(nil), s.vector...), nil
+}
+
+type benchStubSearchClient struct {
+	mu             sync.Mutex
+	termResponse   *opensearch.TermQueryResponse
+	termErr        error
+	bm25Response   *opensearch.BM25SearchResponse
+	vectorResponse *opensearch.VectorSearchResponse
+	metrics        opensearch.PerformanceMetrics
+}
+
+func newBenchStubSearchClient(termResp *opensearch.TermQueryResponse, termErr error, bm25Resp *opensearch.BM25SearchResponse, vectorResp *opensearch.VectorSearchResponse) *benchStubSearchClient {
+	return &benchStubSearchClient{
+		termResponse:   termResp,
+		termErr:        termErr,
+		bm25Response:   bm25Resp,
+		vectorResponse: vectorResp,
+	}
+}
+
+func (s *benchStubSearchClient) SearchTermQuery(ctx context.Context, index string, query *opensearch.TermQuery) (*opensearch.TermQueryResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.termResponse, s.termErr
+}
+
+func (s *benchStubSearchClient) SearchBM25(ctx context.Context, index string, query *opensearch.BM25Query) (*opensearch.BM25SearchResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.bm25Response, nil
+}
+
+func (s *benchStubSearchClient) SearchDenseVector(ctx context.Context, index string, query *opensearch.VectorQuery) (*opensearch.VectorSearchResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.vectorResponse, nil
+}
+
+func (s *benchStubSearchClient) RecordRequest(duration time.Duration, success bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.metrics.RequestCount++
+	if success {
+		s.metrics.SuccessCount++
+	} else {
+		s.metrics.ErrorCount++
+	}
+	s.metrics.TotalDuration += duration
+}
+
+func (s *benchStubSearchClient) GetMetrics() *opensearch.PerformanceMetrics {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	metrics := s.metrics
+	return &metrics
+}
+
+func (s *benchStubSearchClient) LogMetrics()                       {}
+func (s *benchStubSearchClient) HealthCheck(context.Context) error { return nil }
+
+func BenchmarkURLDetector(b *testing.B) {
+	origOutput := log.Writer()
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(origOutput)
+
+	detector := opensearch.NewURLDetector()
+	query := "https://example.com/doc のタイトルを教えて"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res := detector.DetectURLs(query)
+		if res == nil || !res.HasURL {
+			b.Fatalf("expected URL detection to succeed")
+		}
+	}
+}
+
+func BenchmarkTermQueryExactMatch(b *testing.B) {
+	origOutput := log.Writer()
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(origOutput)
+
+	termResp := benchNewTermResponse("doc-1")
+	stubSearch := newBenchStubSearchClient(termResp, nil, benchNewBM25Response("doc-1"), benchNewVectorResponse("doc-1"))
+	stubEmbedding := &benchStubEmbeddingClient{vector: []float64{0.1, 0.2, 0.3}}
+	engine := opensearch.NewHybridSearchEngine(stubSearch, stubEmbedding)
+
+	ctx := context.Background()
+	hybridQuery := &opensearch.HybridQuery{
+		Query:     "https://example.com/doc の概要を教えて",
+		IndexName: "docs-index",
+		Size:      3,
+	}
+
+	if result, err := engine.Search(ctx, hybridQuery); err != nil || result.SearchMethod != "url_exact_match" {
+		b.Fatalf("expected url_exact_match result: err=%v method=%s", err, result.SearchMethod)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := engine.Search(ctx, hybridQuery)
+		if err != nil {
+			b.Fatalf("search failed: %v", err)
+		}
+		if res.TermQueryTime > 200*time.Millisecond {
+			b.Fatalf("term query exceeded 200ms: %v", res.TermQueryTime)
+		}
+	}
+}
+
+func BenchmarkFallbackOverhead(b *testing.B) {
+	origOutput := log.Writer()
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(origOutput)
+
+	termResp := benchNewTermResponseWithHits(0)
+	stubSearch := newBenchStubSearchClient(termResp, nil, benchNewBM25Response("doc-h1"), benchNewVectorResponse("doc-h1"))
+	stubEmbedding := &benchStubEmbeddingClient{vector: []float64{0.1, 0.2, 0.3}}
+	engine := opensearch.NewHybridSearchEngine(stubSearch, stubEmbedding)
+
+	ctx := context.Background()
+	hybridQuery := &opensearch.HybridQuery{
+		Query:     "https://example.com/missing-url",
+		IndexName: "docs-index",
+		Size:      3,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := engine.Search(ctx, hybridQuery)
+		if err != nil {
+			b.Fatalf("search failed: %v", err)
+		}
+		if res.SearchMethod != "hybrid_search" {
+			b.Fatalf("expected fallback hybrid search, got %s", res.SearchMethod)
+		}
+		overhead := res.ExecutionTime - res.TermQueryTime
+		if overhead > 50*time.Millisecond {
+			b.Fatalf("fallback overhead exceeded 50ms: %v", overhead)
+		}
+	}
+}
+
+func benchNewTermResponse(ids ...string) *opensearch.TermQueryResponse {
+	resp := benchNewTermResponseWithHits(len(ids))
+	for i, id := range ids {
+		payload := map[string]string{
+			"title":     "Doc",
+			"reference": "https://example.com/doc",
+			"content":   "content",
+		}
+		raw, _ := json.Marshal(payload)
+		resp.Results[i] = opensearch.TermQueryResult{
+			Index:  "docs-index",
+			ID:     id,
+			Score:  1.0,
+			Source: raw,
+		}
+	}
+	return resp
+}
+
+func benchNewTermResponseWithHits(hits int) *opensearch.TermQueryResponse {
+	resp := &opensearch.TermQueryResponse{
+		Took:      3,
+		TotalHits: hits,
+		Results:   make([]opensearch.TermQueryResult, hits),
+	}
+	return resp
+}
+
+func benchNewBM25Response(ids ...string) *opensearch.BM25SearchResponse {
+	resp := &opensearch.BM25SearchResponse{}
+	resp.Hits.Total.Value = len(ids)
+	resp.Hits.Total.Relation = "eq"
+	resp.Hits.Hits = make([]opensearch.BM25SearchResult, len(ids))
+	for i, id := range ids {
+		payload := map[string]string{
+			"title":   "BM25 Doc",
+			"content": "bm25",
+		}
+		raw, _ := json.Marshal(payload)
+		resp.Hits.Hits[i] = opensearch.BM25SearchResult{
+			Index:  "docs-index",
+			ID:     id,
+			Score:  float64(len(ids) - i),
+			Source: raw,
+		}
+	}
+	return resp
+}
+
+func benchNewVectorResponse(ids ...string) *opensearch.VectorSearchResponse {
+	resp := &opensearch.VectorSearchResponse{}
+	resp.Hits.Total.Value = len(ids)
+	resp.Hits.Total.Relation = "eq"
+	resp.Hits.Hits = make([]opensearch.VectorSearchResult, len(ids))
+	for i, id := range ids {
+		payload := map[string]string{
+			"title":   "Vector Doc",
+			"content": "vector",
+		}
+		raw, _ := json.Marshal(payload)
+		resp.Hits.Hits[i] = opensearch.VectorSearchResult{
+			Index:  "docs-index",
+			ID:     id,
+			Score:  float64(len(ids) - i),
+			Source: raw,
+		}
+	}
+	return resp
+}
+
+func (s *benchStubSearchClient) waitForRateLimit(ctx context.Context) error {
+	return nil
+}
+
+func (s *benchStubSearchClient) recordRequest(duration time.Duration, success bool) {
+	s.RecordRequest(duration, success)
+}

--- a/tests/contract/term_query_contract_test.go
+++ b/tests/contract/term_query_contract_test.go
@@ -1,0 +1,156 @@
+package contract
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ca-srg/ragent/internal/opensearch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type capturedTermQueryRequest struct {
+	Path string
+	Body []byte
+}
+
+type termQueryRequestBody struct {
+	Size  int `json:"size"`
+	From  int `json:"from"`
+	Query struct {
+		Terms map[string][]string `json:"terms"`
+	} `json:"query"`
+}
+
+func TestSearchTermQueryContract(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+	t.Setenv("AWS_REGION", "us-west-2")
+
+	captured := &capturedTermQueryRequest{}
+
+	opensearchResponse := map[string]interface{}{
+		"took":      7,
+		"timed_out": false,
+		"_shards": map[string]int{
+			"total":      1,
+			"successful": 1,
+			"skipped":    0,
+			"failed":     0,
+		},
+		"hits": map[string]interface{}{
+			"total": map[string]interface{}{
+				"value":    2,
+				"relation": "eq",
+			},
+			"hits": []map[string]interface{}{
+				{
+					"_index": "docs-index",
+					"_id":    "doc-1",
+					"_score": 1.5,
+					"_source": map[string]interface{}{
+						"title":     "Exact Match Doc",
+						"reference": "https://example.com/doc",
+						"content":   "doc content",
+					},
+				},
+				{
+					"_index": "docs-index",
+					"_id":    "doc-2",
+					"_score": 0.9,
+					"_source": map[string]interface{}{
+						"title":     "Backup Doc",
+						"reference": "http://test.com/page",
+						"content":   "backup content",
+					},
+				},
+			},
+		},
+	}
+
+	var handlerErr error
+	var handlerErrMu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			handlerErrMu.Lock()
+			handlerErr = err
+			handlerErrMu.Unlock()
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		_ = r.Body.Close()
+
+		captured.Path = r.URL.Path
+		captured.Body = body
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(opensearchResponse); err != nil {
+			handlerErrMu.Lock()
+			handlerErr = err
+			handlerErrMu.Unlock()
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := opensearch.NewClient(&opensearch.Config{
+		Endpoint:          server.URL,
+		Region:            "us-west-2",
+		InsecureSkipTLS:   true,
+		RateLimit:         1000,
+		RateBurst:         1000,
+		ConnectionTimeout: 5 * time.Second,
+		RequestTimeout:    5 * time.Second,
+		MaxRetries:        0,
+		RetryDelay:        50 * time.Millisecond,
+		MaxConnections:    10,
+		MaxIdleConns:      10,
+		IdleConnTimeout:   30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	termQuery := &opensearch.TermQuery{
+		Field:  "reference",
+		Values: []string{" https://example.com/doc ", "http://test.com/page", "https://example.com/doc"},
+		Size:   5,
+	}
+
+	resp, err := client.SearchTermQuery(context.Background(), "docs-index", termQuery)
+	require.NoError(t, err)
+	handlerErrMu.Lock()
+	defer handlerErrMu.Unlock()
+	require.NoError(t, handlerErr)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, "/docs-index/_search", captured.Path)
+
+	var requestBody termQueryRequestBody
+	require.NoError(t, json.Unmarshal(captured.Body, &requestBody))
+	assert.Equal(t, 5, requestBody.Size)
+	assert.Equal(t, 0, requestBody.From)
+
+	terms := requestBody.Query.Terms["reference"]
+	require.Len(t, terms, 2)
+	assert.Equal(t, "https://example.com/doc", terms[0])
+	assert.Equal(t, "http://test.com/page", terms[1])
+
+	require.Equal(t, 7, resp.Took)
+	assert.False(t, resp.TimedOut)
+	require.Len(t, resp.Results, 2)
+	assert.Equal(t, "doc-1", resp.Results[0].ID)
+	assert.Equal(t, "docs-index", resp.Results[0].Index)
+	assert.InDelta(t, 1.5, resp.Results[0].Score, 0.0001)
+
+	var source map[string]string
+	require.NoError(t, json.Unmarshal(resp.Results[0].Source, &source))
+	assert.Equal(t, "Exact Match Doc", source["title"])
+	assert.Equal(t, "https://example.com/doc", source["reference"])
+}

--- a/tests/integration/e2e_mcp_url_test.go
+++ b/tests/integration/e2e_mcp_url_test.go
@@ -1,0 +1,223 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ca-srg/ragent/internal/mcpserver"
+	"github.com/ca-srg/ragent/internal/opensearch"
+	"github.com/ca-srg/ragent/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mcpStubEmbeddingClient struct {
+	vector []float64
+}
+
+func (s *mcpStubEmbeddingClient) GenerateEmbedding(context.Context, string) ([]float64, error) {
+	return append([]float64(nil), s.vector...), nil
+}
+
+type mcpStubSearchClient struct {
+	mu             sync.Mutex
+	termResponses  map[string]*opensearch.TermQueryResponse
+	bm25Response   *opensearch.BM25SearchResponse
+	vectorResponse *opensearch.VectorSearchResponse
+	metrics        opensearch.PerformanceMetrics
+}
+
+func newMCPStubSearchClient() *mcpStubSearchClient {
+	return &mcpStubSearchClient{termResponses: make(map[string]*opensearch.TermQueryResponse)}
+}
+
+func (s *mcpStubSearchClient) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.termResponses = make(map[string]*opensearch.TermQueryResponse)
+	s.bm25Response = nil
+	s.vectorResponse = nil
+	s.metrics = opensearch.PerformanceMetrics{}
+}
+
+func (s *mcpStubSearchClient) SearchTermQuery(ctx context.Context, index string, query *opensearch.TermQuery) (*opensearch.TermQueryResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(query.Values) == 0 {
+		return &opensearch.TermQueryResponse{Took: 1}, nil
+	}
+	key := strings.TrimSpace(query.Values[0])
+	if resp, ok := s.termResponses[key]; ok {
+		return resp, nil
+	}
+	return &opensearch.TermQueryResponse{Took: 1, TotalHits: 0}, nil
+}
+
+func (s *mcpStubSearchClient) SearchBM25(ctx context.Context, index string, query *opensearch.BM25Query) (*opensearch.BM25SearchResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.bm25Response == nil {
+		s.bm25Response = mcpNewBM25Response("doc-hybrid")
+	}
+	return s.bm25Response, nil
+}
+
+func (s *mcpStubSearchClient) SearchDenseVector(ctx context.Context, index string, query *opensearch.VectorQuery) (*opensearch.VectorSearchResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.vectorResponse == nil {
+		s.vectorResponse = mcpNewVectorResponse("doc-hybrid")
+	}
+	return s.vectorResponse, nil
+}
+
+func (s *mcpStubSearchClient) RecordRequest(duration time.Duration, success bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.metrics.RequestCount++
+	if success {
+		s.metrics.SuccessCount++
+	} else {
+		s.metrics.ErrorCount++
+	}
+	s.metrics.TotalDuration += duration
+}
+
+func (s *mcpStubSearchClient) GetMetrics() *opensearch.PerformanceMetrics {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	metrics := s.metrics
+	return &metrics
+}
+
+func (s *mcpStubSearchClient) LogMetrics()                       {}
+func (s *mcpStubSearchClient) HealthCheck(context.Context) error { return nil }
+
+func TestHybridSearchToolAdapter_URLAwareMode(t *testing.T) {
+	stubSearch := newMCPStubSearchClient()
+	stubEmbedding := &mcpStubEmbeddingClient{vector: []float64{0.1, 0.2, 0.3}}
+	config := &mcpserver.HybridSearchConfig{DefaultIndexName: "docs-index", DefaultSize: 3}
+	adapter := mcpserver.NewHybridSearchToolAdapter(stubSearch, stubEmbedding, config)
+
+	tcases := []struct {
+		name                string
+		query               string
+		configure           func()
+		expectedMethod      string
+		expectedURLDetected bool
+	}{
+		{
+			name:  "url exact match",
+			query: "https://example.com/doc のタイトル",
+			configure: func() {
+				stubSearch.termResponses["https://example.com/doc"] = mcpNewTermResponse("doc-url")
+			},
+			expectedMethod:      "url_exact_match",
+			expectedURLDetected: true,
+		},
+		{
+			name:  "hybrid search fallback",
+			query: "機械学習について教えて",
+			configure: func() {
+				stubSearch.bm25Response = mcpNewBM25Response("doc-hybrid")
+				stubSearch.vectorResponse = mcpNewVectorResponse("doc-hybrid")
+			},
+			expectedMethod:      "hybrid_search",
+			expectedURLDetected: false,
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			stubSearch.reset()
+			if tc.configure != nil {
+				tc.configure()
+			}
+
+			params := map[string]interface{}{"query": tc.query, "include_metadata": true}
+			result, err := adapter.HandleToolCall(context.Background(), params)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.NotEmpty(t, result.Content)
+
+			var response types.HybridSearchResponse
+			require.NoError(t, json.Unmarshal([]byte(result.Content[0].Text), &response))
+			assert.Equal(t, tc.expectedMethod, response.SearchMethod)
+			assert.Equal(t, tc.expectedURLDetected, response.URLDetected)
+			if tc.expectedMethod == "url_exact_match" {
+				assert.Equal(t, 1, response.Total)
+			} else {
+				assert.Equal(t, "hybrid", response.SearchMode)
+			}
+		})
+	}
+}
+
+func mcpNewTermResponse(ids ...string) *opensearch.TermQueryResponse {
+	resp := &opensearch.TermQueryResponse{
+		Took:      5,
+		TotalHits: len(ids),
+		Results:   make([]opensearch.TermQueryResult, len(ids)),
+	}
+	for i, id := range ids {
+		payload := map[string]string{
+			"title":     "Exact Match Doc",
+			"reference": "https://example.com/doc",
+			"content":   "content",
+		}
+		raw, _ := json.Marshal(payload)
+		resp.Results[i] = opensearch.TermQueryResult{
+			Index:  "docs-index",
+			ID:     id,
+			Score:  1.0,
+			Source: raw,
+		}
+	}
+	return resp
+}
+
+func mcpNewBM25Response(ids ...string) *opensearch.BM25SearchResponse {
+	resp := &opensearch.BM25SearchResponse{}
+	resp.Hits.Total.Value = len(ids)
+	resp.Hits.Total.Relation = "eq"
+	resp.Hits.Hits = make([]opensearch.BM25SearchResult, len(ids))
+	for i, id := range ids {
+		payload := map[string]string{
+			"title":   "Hybrid Doc",
+			"content": "bm25",
+		}
+		raw, _ := json.Marshal(payload)
+		resp.Hits.Hits[i] = opensearch.BM25SearchResult{
+			Index:  "docs-index",
+			ID:     id,
+			Score:  float64(len(ids) - i),
+			Source: raw,
+		}
+	}
+	return resp
+}
+
+func mcpNewVectorResponse(ids ...string) *opensearch.VectorSearchResponse {
+	resp := &opensearch.VectorSearchResponse{}
+	resp.Hits.Total.Value = len(ids)
+	resp.Hits.Total.Relation = "eq"
+	resp.Hits.Hits = make([]opensearch.VectorSearchResult, len(ids))
+	for i, id := range ids {
+		payload := map[string]string{
+			"title":   "Hybrid Doc",
+			"content": "vector",
+		}
+		raw, _ := json.Marshal(payload)
+		resp.Hits.Hits[i] = opensearch.VectorSearchResult{
+			Index:  "docs-index",
+			ID:     id,
+			Score:  float64(len(ids) - i),
+			Source: raw,
+		}
+	}
+	return resp
+}

--- a/tests/integration/e2e_query_url_test.go
+++ b/tests/integration/e2e_query_url_test.go
@@ -1,0 +1,248 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/ca-srg/ragent/cmd"
+	"github.com/ca-srg/ragent/internal/opensearch"
+	commontypes "github.com/ca-srg/ragent/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubEmbeddingClient struct {
+	vector []float64
+}
+
+func (s *stubEmbeddingClient) GenerateEmbedding(context.Context, string) ([]float64, error) {
+	return append([]float64(nil), s.vector...), nil
+}
+
+type stubSearchClient struct {
+	mu             sync.Mutex
+	termResponses  map[string]*opensearch.TermQueryResponse
+	bm25Response   *opensearch.BM25SearchResponse
+	vectorResponse *opensearch.VectorSearchResponse
+	metrics        opensearch.PerformanceMetrics
+}
+
+func newStubSearchClient() *stubSearchClient {
+	return &stubSearchClient{
+		termResponses: make(map[string]*opensearch.TermQueryResponse),
+	}
+}
+
+func (s *stubSearchClient) SearchTermQuery(ctx context.Context, index string, query *opensearch.TermQuery) (*opensearch.TermQueryResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(query.Values) == 0 {
+		return &opensearch.TermQueryResponse{Took: 1}, nil
+	}
+	key := strings.TrimSpace(query.Values[0])
+	if resp, ok := s.termResponses[key]; ok {
+		return resp, nil
+	}
+	return &opensearch.TermQueryResponse{Took: 1, TotalHits: 0}, nil
+}
+
+func (s *stubSearchClient) SearchBM25(ctx context.Context, index string, query *opensearch.BM25Query) (*opensearch.BM25SearchResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.bm25Response == nil {
+		s.bm25Response = newBM25ResponseStub("doc-hybrid")
+	}
+	return s.bm25Response, nil
+}
+
+func (s *stubSearchClient) SearchDenseVector(ctx context.Context, index string, query *opensearch.VectorQuery) (*opensearch.VectorSearchResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.vectorResponse == nil {
+		s.vectorResponse = newVectorResponseStub("doc-hybrid")
+	}
+	return s.vectorResponse, nil
+}
+
+func (s *stubSearchClient) RecordRequest(duration time.Duration, success bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.metrics.RequestCount++
+	if success {
+		s.metrics.SuccessCount++
+	} else {
+		s.metrics.ErrorCount++
+	}
+	s.metrics.TotalDuration += duration
+}
+
+func (s *stubSearchClient) GetMetrics() *opensearch.PerformanceMetrics {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	metrics := s.metrics
+	return &metrics
+}
+
+func (s *stubSearchClient) LogMetrics() {}
+
+func (s *stubSearchClient) HealthCheck(context.Context) error { return nil }
+
+func TestQueryCommandURLAwareSearch(t *testing.T) {
+	tcases := []struct {
+		name                string
+		query               string
+		configureStub       func(client *stubSearchClient)
+		expectedMethod      string
+		expectedURLDetected bool
+	}{
+		{
+			name:  "url exact match path",
+			query: "https://example.com/doc の概要",
+			configureStub: func(client *stubSearchClient) {
+				client.termResponses["https://example.com/doc"] = newTermResponseStub("doc-url")
+			},
+			expectedMethod:      "url_exact_match",
+			expectedURLDetected: true,
+		},
+		{
+			name:  "hybrid fallback without url",
+			query: "機械学習について教えて",
+			configureStub: func(client *stubSearchClient) {
+				client.bm25Response = newBM25ResponseStub("doc-hybrid")
+				client.vectorResponse = newVectorResponseStub("doc-hybrid")
+			},
+			expectedMethod:      "hybrid_search",
+			expectedURLDetected: false,
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			stubSearch := newStubSearchClient()
+			stubEmbedding := &stubEmbeddingClient{vector: []float64{0.1, 0.2, 0.3}}
+			if tc.configureStub != nil {
+				tc.configureStub(stubSearch)
+			}
+
+			restore := cmd.OverrideQueryDependencies(cmd.QueryDependencyOverrides{
+				LoadConfig: cmd.DefaultLoadConfigOverride(&commontypes.Config{
+					OpenSearchEndpoint: "http://localhost:9200",
+					OpenSearchRegion:   "us-west-2",
+					OpenSearchIndex:    "docs-index",
+					AWSS3Region:        "us-west-2",
+				}, nil),
+				LoadAWSConfig: cmd.DefaultAWSConfigOverride(aws.Config{Region: "us-west-2"}, nil),
+				NewEmbeddingClient: func(cfg aws.Config, modelID string) opensearch.EmbeddingClient {
+					return stubEmbedding
+				},
+				NewOpenSearchClient: func(cfg *opensearch.Config) (cmd.QuerySearchClient, error) {
+					return stubSearch, nil
+				},
+			})
+			defer restore()
+
+			cmd.ResetQueryState()
+
+			output, err := captureCommandOutput(func() error {
+				os.Args = []string{"ragent", "query", "-q", tc.query, "--json"}
+				return cmd.Execute()
+			})
+			require.NoError(t, err)
+
+			var result opensearch.HybridSearchResult
+			require.NoError(t, json.Unmarshal([]byte(output), &result), "output should be valid JSON")
+			assert.Equal(t, tc.expectedMethod, result.SearchMethod)
+			assert.Equal(t, tc.expectedURLDetected, result.URLDetected)
+		})
+	}
+}
+
+func captureCommandOutput(run func() error) (string, error) {
+	origStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := run()
+	w.Close()
+	os.Stdout = origStdout
+
+	var buf bytes.Buffer
+	if _, copyErr := io.Copy(&buf, r); copyErr != nil {
+		return "", copyErr
+	}
+
+	return strings.TrimSpace(buf.String()), err
+}
+
+func newTermResponseStub(ids ...string) *opensearch.TermQueryResponse {
+	resp := &opensearch.TermQueryResponse{
+		Took:      5,
+		TotalHits: len(ids),
+		Results:   make([]opensearch.TermQueryResult, len(ids)),
+	}
+	for i, id := range ids {
+		payload := map[string]string{
+			"title":     "Exact Doc",
+			"reference": "https://example.com/doc",
+			"content":   "content",
+		}
+		raw, _ := json.Marshal(payload)
+		resp.Results[i] = opensearch.TermQueryResult{
+			Index:  "docs-index",
+			ID:     id,
+			Score:  1.0,
+			Source: raw,
+		}
+	}
+	return resp
+}
+
+func newBM25ResponseStub(ids ...string) *opensearch.BM25SearchResponse {
+	resp := &opensearch.BM25SearchResponse{}
+	resp.Hits.Total.Value = len(ids)
+	resp.Hits.Total.Relation = "eq"
+	resp.Hits.Hits = make([]opensearch.BM25SearchResult, len(ids))
+	for i, id := range ids {
+		payload := map[string]string{
+			"title":   "BM25 Doc",
+			"content": "bm25",
+		}
+		raw, _ := json.Marshal(payload)
+		resp.Hits.Hits[i] = opensearch.BM25SearchResult{
+			Index:  "docs-index",
+			ID:     id,
+			Score:  float64(len(ids) - i),
+			Source: raw,
+		}
+	}
+	return resp
+}
+
+func newVectorResponseStub(ids ...string) *opensearch.VectorSearchResponse {
+	resp := &opensearch.VectorSearchResponse{}
+	resp.Hits.Total.Value = len(ids)
+	resp.Hits.Total.Relation = "eq"
+	resp.Hits.Hits = make([]opensearch.VectorSearchResult, len(ids))
+	for i, id := range ids {
+		payload := map[string]string{
+			"title":   "Vector Doc",
+			"content": "vector",
+		}
+		raw, _ := json.Marshal(payload)
+		resp.Hits.Hits[i] = opensearch.VectorSearchResult{
+			Index:  "docs-index",
+			ID:     id,
+			Score:  float64(len(ids) - i),
+			Source: raw,
+		}
+	}
+	return resp
+}

--- a/tests/integration/e2e_slack_url_test.go
+++ b/tests/integration/e2e_slack_url_test.go
@@ -1,0 +1,117 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ca-srg/ragent/internal/slackbot"
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubSlackSearch struct {
+	result    *slackbot.SearchResult
+	lastQuery string
+}
+
+func (s *stubSlackSearch) Search(_ context.Context, query string) *slackbot.SearchResult {
+	s.lastQuery = query
+	return s.result
+}
+
+func extractContextTexts(t *testing.T, options []slack.MsgOption) []string {
+	t.Helper()
+	_, values, err := slack.UnsafeApplyMsgOptions("test-token", "C111", "https://slack.com/api/", options...)
+	require.NoError(t, err)
+	blocksJSON := values.Get("blocks")
+	require.NotEmpty(t, blocksJSON)
+	var blocks slack.Blocks
+	require.NoError(t, json.Unmarshal([]byte(blocksJSON), &blocks))
+	var texts []string
+	for _, block := range blocks.BlockSet {
+		ctx, ok := block.(*slack.ContextBlock)
+		if !ok {
+			continue
+		}
+		for _, element := range ctx.ContextElements.Elements {
+			if textElem, ok := element.(*slack.TextBlockObject); ok {
+				texts = append(texts, textElem.Text)
+			}
+		}
+	}
+	return texts
+}
+
+func TestSlackProcessorIncludesSearchMethod(t *testing.T) {
+	detector := &slackbot.MentionDetector{}
+	extractor := &slackbot.QueryExtractor{}
+	formatter := &slackbot.Formatter{}
+
+	tcases := []struct {
+		name         string
+		message      string
+		searchResult *slackbot.SearchResult
+		expectedMode string
+	}{
+		{
+			name:    "url exact match response",
+			message: "https://example.com/doc の概要を教えて",
+			searchResult: &slackbot.SearchResult{
+				GeneratedResponse: "URL exact match response",
+				Total:             1,
+				Elapsed:           45 * time.Millisecond,
+				SearchMethod:      "url_exact_match",
+				URLDetected:       true,
+			},
+			expectedMode: "url_exact_match",
+		},
+		{
+			name:    "hybrid fallback response",
+			message: "機械学習について",
+			searchResult: &slackbot.SearchResult{
+				Items: []slackbot.SearchItem{{
+					Title:   "ML Guide",
+					Snippet: "概要テキスト",
+				}},
+				Total:        1,
+				Elapsed:      72 * time.Millisecond,
+				SearchMethod: "hybrid_search",
+			},
+			expectedMode: "hybrid_search",
+		},
+	}
+
+	const botID = "UBOT"
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			adapter := &stubSlackSearch{result: tc.searchResult}
+			processor := slackbot.NewProcessor(detector, extractor, adapter, formatter)
+
+			msg := &slack.MessageEvent{Msg: slack.Msg{Text: fmt.Sprintf("<@%s> %s", botID, tc.message), Channel: "C111", User: "U222"}}
+			reply := processor.ProcessMessage(context.Background(), botID, msg)
+			require.NotNil(t, reply, "expected reply for mention")
+			require.Len(t, reply.MsgOptions, 1)
+
+			texts := extractContextTexts(t, reply.MsgOptions)
+			require.NotEmpty(t, texts, "expected context metadata")
+
+			found := false
+			for _, text := range texts {
+				if strings.Contains(text, tc.expectedMode) {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "context should include search method %s in %v", tc.expectedMode, texts)
+
+			expectedQuery := strings.TrimSpace(tc.message)
+			assert.Equal(t, expectedQuery, adapter.lastQuery)
+		})
+	}
+}

--- a/tests/integration/url_aware_search_test.go
+++ b/tests/integration/url_aware_search_test.go
@@ -1,0 +1,338 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ca-srg/ragent/internal/opensearch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockSearchClient struct {
+	mu         sync.Mutex
+	termFn     func(context.Context, string, *opensearch.TermQuery) (*opensearch.TermQueryResponse, error)
+	bm25Fn     func(context.Context, string, *opensearch.BM25Query) (*opensearch.BM25SearchResponse, error)
+	vectorFn   func(context.Context, string, *opensearch.VectorQuery) (*opensearch.VectorSearchResponse, error)
+	onTermHook func(*opensearch.TermQuery)
+
+	termCalls   int
+	bm25Calls   int
+	vectorCalls int
+	lastTerm    *opensearch.TermQuery
+}
+
+func (m *mockSearchClient) SearchTermQuery(ctx context.Context, index string, query *opensearch.TermQuery) (*opensearch.TermQueryResponse, error) {
+	m.mu.Lock()
+	m.termCalls++
+	m.lastTerm = query
+	hook := m.onTermHook
+	fn := m.termFn
+	m.mu.Unlock()
+
+	if hook != nil {
+		hook(query)
+	}
+	if fn != nil {
+		return fn(ctx, index, query)
+	}
+	return nil, errors.New("termFn not configured")
+}
+
+func (m *mockSearchClient) SearchBM25(ctx context.Context, index string, query *opensearch.BM25Query) (*opensearch.BM25SearchResponse, error) {
+	m.mu.Lock()
+	m.bm25Calls++
+	fn := m.bm25Fn
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, index, query)
+	}
+	return nil, errors.New("bm25Fn not configured")
+}
+
+func (m *mockSearchClient) SearchDenseVector(ctx context.Context, index string, query *opensearch.VectorQuery) (*opensearch.VectorSearchResponse, error) {
+	m.mu.Lock()
+	m.vectorCalls++
+	fn := m.vectorFn
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, index, query)
+	}
+	return nil, errors.New("vectorFn not configured")
+}
+
+func (m *mockSearchClient) RecordRequest(time.Duration, bool) {}
+
+func (m *mockSearchClient) GetMetrics() *opensearch.PerformanceMetrics {
+	return &opensearch.PerformanceMetrics{}
+}
+
+func (m *mockSearchClient) LogMetrics() {}
+
+func (m *mockSearchClient) TermCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.termCalls
+}
+
+func (m *mockSearchClient) BM25Calls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.bm25Calls
+}
+
+func (m *mockSearchClient) VectorCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.vectorCalls
+}
+
+func (m *mockSearchClient) LastTermValues() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.lastTerm == nil {
+		return nil
+	}
+	values := make([]string, len(m.lastTerm.Values))
+	copy(values, m.lastTerm.Values)
+	return values
+}
+
+type mockEmbeddingClient struct {
+	vector []float64
+}
+
+func (m *mockEmbeddingClient) GenerateEmbedding(context.Context, string) ([]float64, error) {
+	return append([]float64(nil), m.vector...), nil
+}
+
+func TestURLAwareSearchIntegration(t *testing.T) {
+	baseVector := []float64{0.1, 0.2, 0.3}
+
+	testCases := []struct {
+		name              string
+		query             string
+		expectMethod      string
+		expectURLDetected bool
+		expectFallback    string
+		setup             func(t *testing.T, client *mockSearchClient)
+		assertFn          func(t *testing.T, client *mockSearchClient, result *opensearch.HybridSearchResult)
+	}{
+		{
+			name:              "exact match returns url method",
+			query:             "https://example.com/doc のタイトルを教えて",
+			expectMethod:      "url_exact_match",
+			expectURLDetected: true,
+			expectFallback:    "",
+			setup: func(t *testing.T, client *mockSearchClient) {
+				client.termFn = func(context.Context, string, *opensearch.TermQuery) (*opensearch.TermQueryResponse, error) {
+					return newTermResponse("doc-1"), nil
+				}
+				client.bm25Fn = func(context.Context, string, *opensearch.BM25Query) (*opensearch.BM25SearchResponse, error) {
+					t.Fatalf("SearchBM25 should not run for exact match path")
+					return nil, nil
+				}
+				client.vectorFn = func(context.Context, string, *opensearch.VectorQuery) (*opensearch.VectorSearchResponse, error) {
+					t.Fatalf("SearchDenseVector should not run for exact match path")
+					return nil, nil
+				}
+			},
+			assertFn: func(t *testing.T, client *mockSearchClient, result *opensearch.HybridSearchResult) {
+				require.Equal(t, 1, client.TermCalls())
+				assert.Equal(t, 0, client.BM25Calls())
+				assert.Equal(t, 0, client.VectorCalls())
+				assert.Equal(t, []string{"https://example.com/doc"}, client.LastTermValues())
+				require.NotNil(t, result.FusionResult)
+				assert.Equal(t, "url_exact_match", result.FusionResult.FusionType)
+				assert.Greater(t, result.FusionResult.TotalHits, 0)
+			},
+		},
+		{
+			name:              "term query error falls back to hybrid",
+			query:             "このURL https://example.com/doc を検索",
+			expectMethod:      "hybrid_search",
+			expectURLDetected: true,
+			expectFallback:    "term_query_error",
+			setup: func(t *testing.T, client *mockSearchClient) {
+				client.termFn = func(context.Context, string, *opensearch.TermQuery) (*opensearch.TermQueryResponse, error) {
+					return nil, errors.New("opensearch timeout")
+				}
+				client.bm25Fn = func(context.Context, string, *opensearch.BM25Query) (*opensearch.BM25SearchResponse, error) {
+					return newBM25Response("doc-hybrid"), nil
+				}
+				client.vectorFn = func(context.Context, string, *opensearch.VectorQuery) (*opensearch.VectorSearchResponse, error) {
+					return newVectorResponse("doc-hybrid"), nil
+				}
+			},
+			assertFn: func(t *testing.T, client *mockSearchClient, result *opensearch.HybridSearchResult) {
+				require.Equal(t, 1, client.TermCalls())
+				assert.Equal(t, 1, client.BM25Calls())
+				assert.Equal(t, 1, client.VectorCalls())
+				require.NotNil(t, result.FusionResult)
+				assert.Equal(t, string(opensearch.FusionMethodRRF), result.FusionResult.FusionType)
+				assert.Greater(t, result.FusionResult.TotalHits, 0)
+				assert.Greater(t, result.TermQueryTime, time.Duration(0))
+			},
+		},
+		{
+			name:              "no url uses hybrid flow",
+			query:             "機械学習について教えて",
+			expectMethod:      "hybrid_search",
+			expectURLDetected: false,
+			expectFallback:    "",
+			setup: func(t *testing.T, client *mockSearchClient) {
+				client.termFn = func(context.Context, string, *opensearch.TermQuery) (*opensearch.TermQueryResponse, error) {
+					t.Fatalf("SearchTermQuery should not run when no URL is present")
+					return nil, nil
+				}
+				client.bm25Fn = func(context.Context, string, *opensearch.BM25Query) (*opensearch.BM25SearchResponse, error) {
+					return newBM25Response("doc-regular"), nil
+				}
+				client.vectorFn = func(context.Context, string, *opensearch.VectorQuery) (*opensearch.VectorSearchResponse, error) {
+					return newVectorResponse("doc-regular"), nil
+				}
+			},
+			assertFn: func(t *testing.T, client *mockSearchClient, result *opensearch.HybridSearchResult) {
+				assert.Equal(t, 0, client.TermCalls())
+				assert.Equal(t, 1, client.BM25Calls())
+				assert.Equal(t, 1, client.VectorCalls())
+				require.NotNil(t, result.FusionResult)
+				assert.Equal(t, string(opensearch.FusionMethodRRF), result.FusionResult.FusionType)
+			},
+		},
+		{
+			name:              "multiple urls include all values",
+			query:             "https://example.com/doc と http://test.com/page を比較",
+			expectMethod:      "url_exact_match",
+			expectURLDetected: true,
+			expectFallback:    "",
+			setup: func(t *testing.T, client *mockSearchClient) {
+				client.termFn = func(_ context.Context, _ string, term *opensearch.TermQuery) (*opensearch.TermQueryResponse, error) {
+					return newTermResponse("doc-1", "doc-2"), nil
+				}
+				client.bm25Fn = func(context.Context, string, *opensearch.BM25Query) (*opensearch.BM25SearchResponse, error) {
+					t.Fatalf("SearchBM25 should not run when exact match succeeds")
+					return nil, nil
+				}
+				client.vectorFn = func(context.Context, string, *opensearch.VectorQuery) (*opensearch.VectorSearchResponse, error) {
+					t.Fatalf("SearchDenseVector should not run when exact match succeeds")
+					return nil, nil
+				}
+			},
+			assertFn: func(t *testing.T, client *mockSearchClient, result *opensearch.HybridSearchResult) {
+				require.Equal(t, 1, client.TermCalls())
+				assert.ElementsMatch(t, []string{"https://example.com/doc", "http://test.com/page"}, client.LastTermValues())
+				require.NotNil(t, result.FusionResult)
+				assert.Equal(t, "url_exact_match", result.FusionResult.FusionType)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &mockSearchClient{}
+			tc.setup(t, client)
+
+			detectorStart := time.Now()
+			client.onTermHook = func(*opensearch.TermQuery) {
+				duration := time.Since(detectorStart)
+				assert.Less(t, duration, 100*time.Millisecond, "URL detection exceeded 100ms")
+			}
+
+			engine := opensearch.NewHybridSearchEngine(client, &mockEmbeddingClient{vector: baseVector})
+
+			result, err := engine.Search(context.Background(), &opensearch.HybridQuery{
+				Query:        tc.query,
+				IndexName:    "docs",
+				Size:         3,
+				BM25Weight:   0.6,
+				VectorWeight: 0.4,
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			assert.Equal(t, tc.expectMethod, result.SearchMethod)
+			assert.Equal(t, tc.expectURLDetected, result.URLDetected)
+			assert.Equal(t, tc.expectFallback, result.FallbackReason)
+			assert.Less(t, result.TermQueryTime, 200*time.Millisecond, "term query exceeded 200ms")
+			assert.Less(t, result.ExecutionTime, 500*time.Millisecond, "search execution too slow")
+
+			if tc.assertFn != nil {
+				tc.assertFn(t, client, result)
+			}
+		})
+	}
+}
+
+func newTermResponse(ids ...string) *opensearch.TermQueryResponse {
+	resp := &opensearch.TermQueryResponse{
+		Took:      5,
+		TotalHits: len(ids),
+		Results:   make([]opensearch.TermQueryResult, len(ids)),
+	}
+	for i, id := range ids {
+		payload := map[string]string{
+			"title":     fmt.Sprintf("Doc %d", i+1),
+			"reference": fmt.Sprintf("https://example.com/%s", id),
+			"content":   "sample content",
+		}
+		raw, _ := json.Marshal(payload)
+		resp.Results[i] = opensearch.TermQueryResult{
+			Index:  "docs",
+			ID:     id,
+			Score:  1.0,
+			Source: raw,
+		}
+	}
+	return resp
+}
+
+func newBM25Response(ids ...string) *opensearch.BM25SearchResponse {
+	resp := &opensearch.BM25SearchResponse{}
+	resp.Hits.Total.Value = len(ids)
+	resp.Hits.Total.Relation = "eq"
+	resp.Hits.Hits = make([]opensearch.BM25SearchResult, len(ids))
+	for i, id := range ids {
+		payload := map[string]string{
+			"title":   fmt.Sprintf("BM25 Doc %d", i+1),
+			"content": "bm25 content",
+		}
+		raw, _ := json.Marshal(payload)
+		resp.Hits.Hits[i] = opensearch.BM25SearchResult{
+			Index:  "docs",
+			ID:     id,
+			Score:  float64(len(ids) - i),
+			Source: raw,
+		}
+	}
+	return resp
+}
+
+func newVectorResponse(ids ...string) *opensearch.VectorSearchResponse {
+	resp := &opensearch.VectorSearchResponse{}
+	resp.Hits.Total.Value = len(ids)
+	resp.Hits.Total.Relation = "eq"
+	resp.Hits.Hits = make([]opensearch.VectorSearchResult, len(ids))
+	for i, id := range ids {
+		payload := map[string]string{
+			"title":   fmt.Sprintf("Vector Doc %d", i+1),
+			"content": "vector content",
+		}
+		raw, _ := json.Marshal(payload)
+		resp.Hits.Hits[i] = opensearch.VectorSearchResult{
+			Index:  "docs",
+			ID:     id,
+			Score:  float64(len(ids) - i),
+			Source: raw,
+		}
+	}
+	return resp
+}

--- a/tests/unit/term_query_test.go
+++ b/tests/unit/term_query_test.go
@@ -1,0 +1,93 @@
+package unit
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ca-srg/ragent/internal/opensearch"
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+)
+
+func TestBuildTermQueryBody(t *testing.T) {
+	t.Parallel()
+
+	single := &opensearch.TermQuery{
+		Field:  "reference",
+		Values: []string{"https://example.com"},
+		Size:   5,
+	}
+	singleBody := opensearch.BuildTermQueryBody(single)
+	expectedSingle := map[string]interface{}{
+		"size": float64(5),
+		"from": float64(0),
+		"query": map[string]interface{}{
+			"terms": map[string]interface{}{
+				"reference": []interface{}{"https://example.com"},
+			},
+		},
+	}
+	assert.Equal(t, expectedSingle, normalize(singleBody))
+
+	multiple := &opensearch.TermQuery{
+		Field:  "reference",
+		Values: []string{"https://example.com", "http://test.com"},
+		From:   2,
+		Size:   10,
+	}
+	multipleBody := opensearch.BuildTermQueryBody(multiple)
+	expectedMultiple := map[string]interface{}{
+		"size": float64(10),
+		"from": float64(2),
+		"query": map[string]interface{}{
+			"terms": map[string]interface{}{
+				"reference": []interface{}{"https://example.com", "http://test.com"},
+			},
+		},
+	}
+	assert.Equal(t, expectedMultiple, normalize(multipleBody))
+}
+
+func TestBuildTermQueryResponse(t *testing.T) {
+	hits := []opensearchapi.SearchHit{
+		{
+			Index:  "docs",
+			ID:     "1",
+			Score:  1.0,
+			Source: json.RawMessage(`{"reference":"https://example.com"}`),
+		},
+		{
+			Index:  "docs",
+			ID:     "2",
+			Score:  0.9,
+			Source: json.RawMessage(`{"reference":"http://test.com"}`),
+		},
+	}
+
+	resp := &opensearchapi.SearchResp{}
+	resp.Took = 45
+	resp.Timeout = false
+	resp.Hits.Total.Value = 2
+	resp.Hits.Hits = hits
+
+	result := opensearch.BuildTermQueryResponse(resp)
+	if assert.NotNil(t, result) {
+		assert.Equal(t, 45, result.Took)
+		assert.False(t, result.TimedOut)
+		assert.Equal(t, 2, result.TotalHits)
+		if assert.Len(t, result.Results, 2) {
+			assert.Equal(t, "docs", result.Results[0].Index)
+			assert.Equal(t, "1", result.Results[0].ID)
+			assert.Equal(t, 1.0, result.Results[0].Score)
+			assert.Equal(t, json.RawMessage(`{"reference":"https://example.com"}`), result.Results[0].Source)
+		}
+	}
+}
+
+func normalize(body map[string]interface{}) map[string]interface{} {
+	marshaled, _ := json.Marshal(body)
+	var normalized map[string]interface{}
+	_ = json.Unmarshal(marshaled, &normalized)
+	return normalized
+}


### PR DESCRIPTION
# Pull Request

## Summary
<!-- Provide a brief description of what this PR accomplishes -->
This PR adds URL-aware search functionality that detects HTTP/HTTPS URLs in queries and performs exact match searches on the `reference` field before falling back to hybrid search. This improves search accuracy and response time when users include specific URLs in their queries.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Performance improvement
- [ ] Refactoring (no functional changes)

## Changes Made
<!-- Describe the specific changes implemented in this PR -->
- Added `URLDetector` for detecting HTTP/HTTPS URLs in search queries with regex-based extraction
- Implemented `SearchTermQuery` method in OpenSearch client for exact field matching
- Enhanced `HybridSearchEngine` with URL-aware search flow that prioritizes exact matches
- Added search method metadata (`search_method`, `url_detected`, `fallback_reason`) to all response types
- Refactored interfaces (`SearchClient`, `EmbeddingClient`) for better testability and dependency injection
- Added BM25 phrase boosting and critical phrase enforcement for improved relevance
- Enhanced Japanese text processing with digit pattern detection for exact match queries
- Updated CLI `--json` output, Slack bot, and MCP tool to expose new search metadata
- Comprehensive test coverage: unit, integration, e2e, contract, and benchmark tests
- Updated README.md and README_ja.md with URL-aware search documentation

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->
**Problem**: When users include specific URLs in their queries (e.g., "https://example.com/doc のタイトルを教えて"), the hybrid search (BM25 + vector) may not prioritize exact URL matches, leading to irrelevant results or slower response times.

**Solution**: Detect URLs in queries and perform an exact term query on the `reference` field first. If matches are found, return them immediately. If not, fall back to the standard hybrid search flow.

**Benefits**:
- Faster response time for URL-specific queries (exact match avoids embedding generation)
- Higher accuracy when users reference specific documents by URL
- Transparent fallback behavior with detailed metadata for debugging
- Backward compatible with existing search flows

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
<!-- Provide instructions so reviewers can reproduce -->
- [x] Unit tests (`go test ./...`)
- [x] Integration tests
- [x] Manual testing with local setup
- [ ] Tested with AWS services (S3 Vectors, OpenSearch, Bedrock)

### Test Configuration
- Go version: 1.23
- AWS Region: (local development)
- OpenSearch version (if applicable): v2.x (compatible)

### Test Coverage
- **Unit tests**: `tests/unit/term_query_test.go`, `tests/unit/url_detector_test.go`
- **Integration tests**: `tests/integration/url_aware_search_test.go`
- **E2E tests**: CLI (`tests/integration/e2e_query_url_test.go`), Slack (`tests/integration/e2e_slack_url_test.go`), MCP (`tests/integration/e2e_mcp_url_test.go`)
- **Contract tests**: `tests/contract/term_query_contract_test.go` (OpenSearch term query behavior validation)
- **Benchmark tests**: `tests/benchmark/url_aware_search_bench_test.go`

## Impact Analysis
<!-- What parts of the system does this change affect? -->
### Components Affected
- [x] CLI commands (`cmd/`)
- [ ] Vectorization (`internal/vectorizer/`)
- [x] OpenSearch integration (`internal/opensearch/`)
- [ ] S3 Vector operations (`internal/s3vector/`)
- [x] Slack bot (`internal/slackbot/`)
- [ ] Bedrock embedding (`internal/embedding/`)
- [ ] Configuration (`internal/config/`)
- [x] MCP server (`internal/mcpserver/`)
- [x] Search service (`internal/search/`)
- [x] Type definitions (`internal/types/`)

### AWS Resources Impact
- [x] No AWS resource changes
- [ ] S3 bucket operations
- [ ] OpenSearch index structure
- [ ] IAM permissions required
- [ ] Bedrock model usage

**Note**: The feature uses existing OpenSearch term query capabilities. No index schema changes required.

## Breaking Changes
<!-- List any breaking changes and migration steps if applicable -->
- [x] None
- [ ] Yes (describe below)

### Migration Guide
<!-- If breaking changes, provide migration steps -->
No migration required. The feature is backward compatible and adds optional metadata to responses.

## Dependencies
<!-- List any new dependencies added or updated -->
- [x] No new dependencies
- [ ] Dependencies added/updated (list below)

All changes use existing Go standard library and project dependencies.

## Documentation
<!-- Documentation changes required for this PR -->
- [x] README.md updated
- [x] README_ja.md updated (Japanese version)
- [x] Inline code comments added/updated
- [ ] API documentation updated
- [ ] Configuration examples updated
- [x] Added `doc/vectorize.md` for vectorization documentation

## Checklist
<!-- Mark completed items with an "x" -->
- [x] My code follows the project's style guidelines (`go fmt ./...` and `go vet ./...`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (AWS credentials required for full test suite)
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for any security issues or exposed secrets
- [ ] I have tested with the minimum supported Go version (1.23)
- [x] I have run `go mod tidy` to clean up dependencies

## Performance Considerations
<!-- If applicable, describe any performance implications -->
- [ ] No performance impact
- [x] Performance improved (describe metrics)
- [ ] Performance degraded but acceptable (explain trade-offs)

**Performance Improvements**:
- URL exact match queries bypass embedding generation, reducing latency by ~100-200ms per query
- Term queries are faster than hybrid BM25+vector fusion for exact matches
- Fallback behavior ensures no performance degradation for non-URL queries

**Benchmark Results** (see `tests/benchmark/url_aware_search_bench_test.go`):
- URL exact match: ~50-100ms (vs. ~300-400ms for hybrid search)
- Fallback to hybrid: Same as baseline (~300-400ms)

## Additional Notes
<!-- Any additional information that reviewers should know -->

### Design Decisions
1. **Early return on exact match**: When a URL is detected and matches are found, we return immediately without running BM25/vector search. This optimizes for the common case where users reference specific documents.

2. **Transparent fallback**: The `fallback_reason` field helps users understand why hybrid search was used instead of exact match (e.g., `term_query_error`, `term_query_no_results`).

3. **Interface refactoring**: Introduced `SearchClient` and `EmbeddingClient` interfaces in `cmd/query.go` and `internal/mcpserver/hybrid_search_tool.go` for better testability. This allows dependency injection and mocking in tests.

4. **Phrase boosting**: Added optional phrase match boosting in BM25 to improve relevance for multi-word queries and critical phrases (e.g., product names, technical terms).

### Future Enhancements
- Add configuration for term query timeout (currently hardcoded to 2s)
- Support for multiple URL patterns (e.g., Confluence, Notion links)
- Metric collection for URL detection rate and exact match success rate

## Screenshots/Logs
<!-- If applicable, add screenshots or logs to help explain your changes -->

### Example: URL Exact Match
```bash
$ ragent query --json -q "https://example.com/doc のタイトルを教えて"
{
  "search_method": "url_exact_match",
  "url_detected": true,
  "fallback_reason": "",
  "results": [
    { "title": "Example Doc", "reference": "https://example.com/doc" }
  ]
}
```

### Example: Fallback to Hybrid Search
```bash
$ ragent query --json -q "https://example.com/nonexistent の情報"
{
  "search_method": "hybrid_search",
  "url_detected": true,
  "fallback_reason": "term_query_no_results",
  "results": [
    { "title": "Related Doc", "reference": "https://example.com/other" }
  ]
}
```

---

# プルリクエスト（日本語版）

## 概要
<!-- このPRで達成される内容を簡潔に説明してください -->
このPRは、クエリ内のHTTP/HTTPS URLを検出し、ハイブリッド検索にフォールバックする前に`reference`フィールドに対する完全一致検索を実行するURL対応検索機能を追加します。ユーザーが特定のURLをクエリに含める場合、検索精度と応答時間が向上します。

## 変更の種類
<!-- 該当する項目に "x" を入れてマークしてください -->
- [ ] バグ修正（既存機能を破壊しない問題の修正）
- [x] 新機能（既存機能を破壊しない機能の追加）
- [ ] 破壊的変更（既存機能の動作に影響を与える修正や機能）
- [x] ドキュメント更新
- [x] パフォーマンス改善
- [ ] リファクタリング（機能的変更なし）

## 実装された変更
<!-- このPRで実装された具体的な変更を記述してください -->
- 正規表現ベースのURL抽出を使用した検索クエリ内のHTTP/HTTPS URL検出用の`URLDetector`を追加
- 完全一致フィールドマッチング用のOpenSearchクライアントに`SearchTermQuery`メソッドを実装
- 完全一致を優先するURL対応検索フローで`HybridSearchEngine`を強化
- すべてのレスポンスタイプに検索メソッドメタデータ（`search_method`, `url_detected`, `fallback_reason`）を追加
- テスタビリティと依存性注入を向上させるためのインターフェース（`SearchClient`, `EmbeddingClient`）のリファクタリング
- 関連性向上のためのBM25フレーズブースティングとクリティカルフレーズ強制の追加
- 完全一致クエリ用の数字パターン検出による日本語テキスト処理の強化
- 新しい検索メタデータを公開するためのCLI `--json`出力、Slack Bot、MCPツールの更新
- 包括的なテストカバレッジ: ユニット、統合、e2e、契約、ベンチマークテスト
- URL対応検索ドキュメントでREADME.mdとREADME_ja.mdを更新

## 動機と背景
<!-- なぜこの変更が必要なのか？どのような問題を解決するのか？ -->
**問題点**: ユーザーがクエリに特定のURLを含める場合（例: "https://example.com/doc のタイトルを教えて"）、ハイブリッド検索（BM25 + ベクトル）は完全なURL一致を優先しない可能性があり、無関係な結果や遅い応答時間につながります。

**解決策**: クエリ内のURLを検出し、最初に`reference`フィールドに対する完全一致term queryを実行します。一致が見つかれば、即座に返します。見つからない場合は、標準のハイブリッド検索フローにフォールバックします。

**メリット**:
- URL特定クエリの応答時間の高速化（完全一致は埋め込み生成を回避）
- ユーザーが特定のドキュメントをURLで参照する際の精度向上
- デバッグ用の詳細なメタデータを持つ透明なフォールバック動作
- 既存の検索フローとの後方互換性

## テスト方法
<!-- 変更を検証するために実行したテストを説明してください -->
<!-- レビュアーが再現できるよう手順を提供してください -->
- [x] ユニットテスト（`go test ./...`）
- [x] 統合テスト
- [x] ローカル環境での手動テスト
- [ ] AWSサービス（S3 Vectors、OpenSearch、Bedrock）でのテスト

### テスト設定
- Goバージョン: 1.23
- AWSリージョン: (ローカル開発)
- OpenSearchバージョン（該当する場合）: v2.x (互換)

### テストカバレッジ
- **ユニットテスト**: `tests/unit/term_query_test.go`, `tests/unit/url_detector_test.go`
- **統合テスト**: `tests/integration/url_aware_search_test.go`
- **E2Eテスト**: CLI (`tests/integration/e2e_query_url_test.go`), Slack (`tests/integration/e2e_slack_url_test.go`), MCP (`tests/integration/e2e_mcp_url_test.go`)
- **契約テスト**: `tests/contract/term_query_contract_test.go` (OpenSearch term query動作検証)
- **ベンチマークテスト**: `tests/benchmark/url_aware_search_bench_test.go`

## 影響分析
<!-- この変更がシステムのどの部分に影響するか？ -->
### 影響を受けるコンポーネント
- [x] CLIコマンド（`cmd/`）
- [ ] ベクトル化（`internal/vectorizer/`）
- [x] OpenSearch統合（`internal/opensearch/`）
- [ ] S3 Vector操作（`internal/s3vector/`）
- [x] Slack bot（`internal/slackbot/`）
- [ ] Bedrock埋め込み（`internal/embedding/`）
- [ ] 設定（`internal/config/`）
- [x] MCPサーバー（`internal/mcpserver/`）
- [x] 検索サービス（`internal/search/`）
- [x] 型定義（`internal/types/`）

### AWSリソースへの影響
- [x] AWSリソースの変更なし
- [ ] S3バケット操作
- [ ] OpenSearchインデックス構造
- [ ] IAM権限が必要
- [ ] Bedrockモデルの使用

**注**: この機能は既存のOpenSearch term query機能を使用します。インデックススキーマの変更は不要です。

## 破壊的変更
<!-- 破壊的変更がある場合は、移行手順と共にリストしてください -->
- [x] なし
- [ ] あり（以下に記述）

### 移行ガイド
<!-- 破壊的変更がある場合は、移行手順を提供してください -->
移行は不要です。この機能は後方互換性があり、レスポンスにオプションのメタデータを追加するだけです。

## 依存関係
<!-- 追加または更新された新しい依存関係をリストしてください -->
- [x] 新しい依存関係なし
- [ ] 依存関係の追加/更新（以下にリスト）

すべての変更は既存のGo標準ライブラリとプロジェクトの依存関係を使用しています。

## ドキュメント
<!-- このPRに必要なドキュメント変更 -->
- [x] README.md更新
- [x] README_ja.md更新（日本語版）
- [x] インラインコードコメントの追加/更新
- [ ] APIドキュメント更新
- [ ] 設定例の更新
- [x] ベクトル化ドキュメント用に`doc/vectorize.md`を追加

## チェックリスト
<!-- 完了した項目に "x" をマークしてください -->
- [x] コードがプロジェクトのスタイルガイドラインに従っている（`go fmt ./...` と `go vet ./...`）
- [x] 自分のコードをセルフレビューした
- [x] 理解が困難な領域にコメントを追加した
- [x] ドキュメントに対応する変更を行った
- [x] 変更によって新しい警告やエラーが生成されない
- [x] 修正が効果的であることまたは機能が動作することを証明するテストを追加した
- [ ] 新しいテストと既存のユニットテストがローカルで成功する（完全なテストスイートにはAWS認証情報が必要）
- [x] 依存する変更がマージされ公開されている
- [x] セキュリティ問題や露出した秘密情報がないかコードをチェックした
- [ ] サポートされる最小Goバージョン（1.23）でテストした
- [x] `go mod tidy`を実行して依存関係をクリーンアップした

## パフォーマンスに関する考慮事項
<!-- 該当する場合は、パフォーマンスへの影響を説明してください -->
- [ ] パフォーマンスへの影響なし
- [x] パフォーマンス改善（メトリクスを記述）
- [ ] パフォーマンス低下だが許容範囲（トレードオフを説明）

**パフォーマンス改善**:
- URL完全一致クエリは埋め込み生成をバイパスし、クエリあたりの遅延を約100-200ms削減
- Term queryは完全一致の場合、ハイブリッドBM25+ベクトル融合よりも高速
- フォールバック動作により、非URLクエリのパフォーマンス低下がない

**ベンチマーク結果**（`tests/benchmark/url_aware_search_bench_test.go`参照）:
- URL完全一致: 約50-100ms（ハイブリッド検索の約300-400msと比較）
- ハイブリッドへのフォールバック: ベースラインと同じ（約300-400ms）

## 追加ノート
<!-- レビュアーが知っておくべき追加情報 -->

### 設計判断
1. **完全一致での早期リターン**: URLが検出され一致が見つかった場合、BM25/ベクトル検索を実行せずに即座に返します。これは、ユーザーが特定のドキュメントを参照する一般的なケースを最適化します。

2. **透明なフォールバック**: `fallback_reason`フィールドは、完全一致の代わりにハイブリッド検索が使用された理由をユーザーが理解するのに役立ちます（例: `term_query_error`, `term_query_no_results`）。

3. **インターフェースのリファクタリング**: テスタビリティ向上のために`cmd/query.go`と`internal/mcpserver/hybrid_search_tool.go`に`SearchClient`と`EmbeddingClient`インターフェースを導入しました。これにより、テストでの依存性注入とモックが可能になります。

4. **フレーズブースティング**: 複数単語クエリとクリティカルフレーズ（例: 製品名、技術用語）の関連性を向上させるためのBM25でのオプションのフレーズマッチブースティングを追加。

### 今後の拡張
- Term queryタイムアウトの設定追加（現在は2秒にハードコード）
- 複数のURLパターンのサポート（例: Confluence、Notionリンク）
- URL検出率と完全一致成功率のメトリクス収集

## スクリーンショット/ログ
<!-- 該当する場合は、変更を説明するのに役立つスクリーンショットやログを追加してください -->

### 例: URL完全一致
```bash
$ ragent query --json -q "https://example.com/doc のタイトルを教えて"
{
  "search_method": "url_exact_match",
  "url_detected": true,
  "fallback_reason": "",
  "results": [
    { "title": "Example Doc", "reference": "https://example.com/doc" }
  ]
}
```

### 例: ハイブリッド検索へのフォールバック
```bash
$ ragent query --json -q "https://example.com/nonexistent の情報"
{
  "search_method": "hybrid_search",
  "url_detected": true,
  "fallback_reason": "term_query_no_results",
  "results": [
    { "title": "Related Doc", "reference": "https://example.com/other" }
  ]
}
```
