### PR TITLE
feat(slacksearch): add configurable LLM timeout setting

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -154,6 +154,10 @@ func validateSlackSearchConfig(config *Config) error {
 		return fmt.Errorf("SLACK_SEARCH_TIMEOUT_SECONDS must be between 1 and 60 (got %d)", config.SlackSearchTimeoutSeconds)
 	}
 
+	if config.SlackSearchLLMTimeoutSeconds <= 0 || config.SlackSearchLLMTimeoutSeconds > 300 {
+		return fmt.Errorf("SLACK_SEARCH_LLM_TIMEOUT_SECONDS must be between 1 and 300 (got %d)", config.SlackSearchLLMTimeoutSeconds)
+	}
+
 	return nil
 }
 

--- a/internal/slacksearch/query_generator_test.go
+++ b/internal/slacksearch/query_generator_test.go
@@ -22,7 +22,7 @@ func (m *mockBedrockClient) GenerateChatResponse(ctx context.Context, messages [
 }
 
 func newTestQueryGenerator(client bedrockChatClient, now time.Time) *QueryGenerator {
-	qg := NewQueryGenerator(nil)
+	qg := NewQueryGenerator(nil, 60*time.Second)
 	qg.bedrockClient = client
 	qg.nowFunc = func() time.Time { return now }
 	qg.logger.SetOutput(io.Discard)

--- a/internal/slacksearch/sufficiency_checker_test.go
+++ b/internal/slacksearch/sufficiency_checker_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"testing"
+	"time"
 
 	"github.com/ca-srg/ragent/internal/embedding/bedrock"
 	"github.com/slack-go/slack"
@@ -23,7 +24,7 @@ func (m *mockSufficiencyBedrockClient) GenerateChatResponse(ctx context.Context,
 }
 
 func newTestSufficiencyChecker(client bedrockChatClient) *SufficiencyChecker {
-	checker := NewSufficiencyChecker(nil, log.New(io.Discard, "", 0))
+	checker := NewSufficiencyChecker(nil, log.New(io.Discard, "", 0), 60*time.Second)
 	checker.bedrockClient = client
 	return checker
 }

--- a/internal/slacksearch/types.go
+++ b/internal/slacksearch/types.go
@@ -19,6 +19,7 @@ type SlackSearchConfig struct {
 	MaxIterations        int    `json:"max_iterations"`
 	MaxContextMessages   int    `json:"max_context_messages"`
 	TimeoutSeconds       int    `json:"timeout_seconds"`
+	LLMTimeoutSeconds    int    `json:"llm_timeout_seconds"`
 }
 
 // TimeRange represents optional temporal bounds for Slack queries.
@@ -79,6 +80,9 @@ func (c *SlackSearchConfig) Validate() error {
 	}
 	if c.TimeoutSeconds <= 0 || c.TimeoutSeconds > 60 {
 		return fmt.Errorf("timeout_seconds must be between 1 and 60 (got %d)", c.TimeoutSeconds)
+	}
+	if c.LLMTimeoutSeconds <= 0 || c.LLMTimeoutSeconds > 300 {
+		return fmt.Errorf("llm_timeout_seconds must be between 1 and 300 (got %d)", c.LLMTimeoutSeconds)
 	}
 
 	return nil

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -184,6 +184,7 @@ type Config struct {
 	SlackSearchMaxIterations        int    `json:"slack_search_max_iterations" env:"SLACK_SEARCH_MAX_ITERATIONS,default=5"`
 	SlackSearchMaxContextMessages   int    `json:"slack_search_max_context_messages" env:"SLACK_SEARCH_MAX_CONTEXT_MESSAGES,default=100"`
 	SlackSearchTimeoutSeconds       int    `json:"slack_search_timeout_seconds" env:"SLACK_SEARCH_TIMEOUT_SECONDS,default=60"`
+	SlackSearchLLMTimeoutSeconds    int    `json:"slack_search_llm_timeout_seconds" env:"SLACK_SEARCH_LLM_TIMEOUT_SECONDS,default=60"`
 
 	// Observability (OpenTelemetry) configuration
 	OTelEnabled              bool    `json:"otel_enabled" env:"OTEL_ENABLED,default=false"`


### PR DESCRIPTION
# Pull Request

## Summary
Slack検索パイプラインのLLMリクエストタイムアウトを環境変数で設定可能にしました。

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Changes Made
- `SLACK_SEARCH_LLM_TIMEOUT_SECONDS` 環境変数を追加（デフォルト: 60秒、範囲: 1-300秒）
- `QueryGenerator`, `SufficiencyChecker`, `ContextRetriever` で設定可能なタイムアウトを使用
- ハードコードされたタイムアウト定数を削除
- バリデーションを追加

## Motivation and Context
Bedrock LLMへのリクエストがハードコードされた30秒（一部10秒）でタイムアウトし、高負荷時にエラーが発生していました。

**エラーログ例:**
```
[HybridSearchTool] Slack search error: failed to generate Slack queries:
failed to invoke bedrock for query generation: LLMリクエストがタイムアウトしました (llmRequestTimeout=30s)
```

## How Has This Been Tested?
- [x] Unit tests (`go test ./...`)
- [ ] Integration tests
- [ ] Manual testing with local setup
- [ ] Tested with AWS services (S3 Vectors, OpenSearch, Bedrock)

### Test Configuration
- Go version: 1.23
- AWS Region: ap-northeast-1

## Impact Analysis
### Components Affected
- [ ] CLI commands (`cmd/`)
- [ ] Vectorization (`internal/vectorizer/`)
- [ ] OpenSearch integration (`internal/opensearch/`)
- [ ] S3 Vector operations (`internal/s3vector/`)
- [ ] Slack bot (`internal/slackbot/`)
- [ ] Bedrock embedding (`internal/embedding/`)
- [x] Configuration (`internal/config/`)

### AWS Resources Impact
- [x] No AWS resource changes
- [ ] S3 bucket operations
- [ ] OpenSearch index structure
- [ ] IAM permissions required
- [ ] Bedrock model usage

## Breaking Changes
- [x] None
- [ ] Yes (describe below)

## Dependencies
- [x] No new dependencies
- [ ] Dependencies added/updated (list below)

## Documentation
- [ ] README.md updated
- [ ] CLAUDE.md updated
- [ ] Inline code comments added/updated
- [ ] API documentation updated
- [ ] Configuration examples updated

## Checklist
- [x] My code follows the project's style guidelines (`go fmt ./...` and `go vet ./...`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for any security issues or exposed secrets
- [x] I have tested with the minimum supported Go version (1.23)
- [x] I have run `go mod tidy` to clean up dependencies

## Performance Considerations
- [x] No performance impact
- [ ] Performance improved (describe metrics)
- [ ] Performance degraded but acceptable (explain trade-offs)

## Additional Notes
### 新しい環境変数

| 変数名 | デフォルト | 範囲 | 説明 |
|--------|-----------|------|------|
| `SLACK_SEARCH_LLM_TIMEOUT_SECONDS` | 60 | 1-300 | Bedrock LLMリクエストのタイムアウト秒数 |

### 変更前後の比較

| コンポーネント | 変更前 | 変更後 |
|----------------|--------|--------|
| QueryGenerator | 30秒（ハードコード） | 環境変数で設定可能 |
| SufficiencyChecker | 10秒（ハードコード） | 環境変数で設定可能 |
| ContextRetriever | 30秒（ハードコード） | 環境変数で設定可能 |
