### PR TITLE
fix: correct OpenSearch field name for URL term query

### DIFF
--- a/cmd/mcp-server.go
+++ b/cmd/mcp-server.go
@@ -488,7 +488,7 @@ func buildHybridSearchToolDefinition(base *mcp.Tool, toolName string, defaults *
 	toolCopy.Name = toolName
 
 	toolCopy.Description = fmt.Sprintf(
-		"ハイブリッド検索ツール。RAGent の OpenSearch (BM25) と Titan ベクトル検索を組み合わせ、最大 %d 件の候補を融合スコアで返します。日本語・英語いずれの自然文クエリにも対応し、手順書・設計資料・ナレッジノートを横断的に調べる用途を想定しています。必要に応じて `enable_slack_search` を true にすることで社内 Slack の会話も同時に検索でき、`slack_channels` でチャンネルを絞り込めます。レスポンスは JSON テキストで、各ドキュメントのタイトル/抜粋/スコア/パス/メタデータ (任意) を含みます。\n\nEnglish: Run hybrid retrieval across the Markdown knowledge base by blending BM25 and Titan embeddings on Amazon OpenSearch. Returns up to %d ranked documents with fused scores plus optional metadata. Set `enable_slack_search` to true to enrich the response with Slack conversations and use `slack_channels` to scope the workspace search.",
+		"ハイブリッド検索ツール。RAGent の OpenSearch (BM25) と Titan ベクトル検索を組み合わせ、最大 %d 件の候補を融合スコアで返します。日本語・英語いずれの自然文クエリにも対応し、手順書・設計資料・ナレッジノートを横断的に調べる用途を想定しています。必要に応じて `enable_slack_search` を true にすることで社内 Slack の会話も同時に検索できます。レスポンスは JSON テキストで、各ドキュメントのタイトル/抜粋/スコア/パス/メタデータ (任意) を含みます。\n\nEnglish: Run hybrid retrieval across the Markdown knowledge base by blending BM25 and Titan embeddings on Amazon OpenSearch. Returns up to %d ranked documents with fused scores plus optional metadata. Set `enable_slack_search` to true to enrich the response with Slack conversations.",
 		defaults.DefaultSize,
 		defaults.DefaultSize,
 	)
@@ -618,10 +618,6 @@ func buildHybridSearchToolDefinition(base *mcp.Tool, toolName string, defaults *
 	slackToggleProp.Description = "Slack のワークスペース会話を同時に検索する場合は true を指定します。サーバー側で Slack の資格情報が設定されている必要があります。"
 	slackToggleProp.Default = toRaw(false)
 
-	slackChannelsProp := ensureProperty("slack_channels", "array")
-	slackChannelsProp.Title = "Slack Channels"
-	slackChannelsProp.Description = "Slack 検索対象のチャンネル名リスト。先頭の # を付けずに指定します。省略した場合は全チャンネルが対象です。"
-	slackChannelsProp.Items = &jsonschema.Schema{Type: "string", Description: "Slack channel name (without '#')."}
 
 	schema.Properties["query"] = queryProp
 	schema.Properties["top_k"] = topKProp
@@ -634,7 +630,6 @@ func buildHybridSearchToolDefinition(base *mcp.Tool, toolName string, defaults *
 	schema.Properties["fusion_method"] = fusionMethodProp
 	schema.Properties["use_japanese_nlp"] = nlpProp
 	schema.Properties["enable_slack_search"] = slackToggleProp
-	schema.Properties["slack_channels"] = slackChannelsProp
 
 	schema.Examples = []any{
 		map[string]any{
@@ -651,7 +646,6 @@ func buildHybridSearchToolDefinition(base *mcp.Tool, toolName string, defaults *
 			"min_score":           0.25,
 			"filters":             map[string]any{"tags": "observability"},
 			"enable_slack_search": true,
-			"slack_channels":      []string{"incident-updates"},
 		},
 	}
 

--- a/cmd/mcp-server.go
+++ b/cmd/mcp-server.go
@@ -618,7 +618,6 @@ func buildHybridSearchToolDefinition(base *mcp.Tool, toolName string, defaults *
 	slackToggleProp.Description = "Slack のワークスペース会話を同時に検索する場合は true を指定します。サーバー側で Slack の資格情報が設定されている必要があります。"
 	slackToggleProp.Default = toRaw(false)
 
-
 	schema.Properties["query"] = queryProp
 	schema.Properties["top_k"] = topKProp
 	schema.Properties["filters"] = filtersProp

--- a/internal/opensearch/hybrid_engine.go
+++ b/internal/opensearch/hybrid_engine.go
@@ -129,7 +129,7 @@ func (hse *HybridSearchEngine) Search(ctx context.Context, query *HybridQuery) (
 			log.Printf("URL detected in query: %v", detectionResult.URLs)
 			urlDetected = true
 			termQuery := &TermQuery{
-				Field:  "reference.keyword",
+				Field:  "reference",
 				Values: detectionResult.URLs,
 				Size:   query.Size,
 			}
@@ -137,7 +137,7 @@ func (hse *HybridSearchEngine) Search(ctx context.Context, query *HybridQuery) (
 				termQuery.Size = len(detectionResult.URLs)
 			}
 
-			log.Printf("Executing term query on 'reference.keyword' field for %d URL(s)", len(detectionResult.URLs))
+			log.Printf("Executing term query on 'reference' field for %d URL(s)", len(detectionResult.URLs))
 			termStart := time.Now()
 			termResponse, err := hse.client.SearchTermQuery(ctx, query.IndexName, termQuery)
 			termQueryDuration = time.Since(termStart)

--- a/internal/slacksearch/query_generator.go
+++ b/internal/slacksearch/query_generator.go
@@ -65,8 +65,8 @@ type QueryGenerationResponse struct {
 }
 
 type llmQueryPayload struct {
-	Queries   []string `json:"queries"`
-	Reasoning string   `json:"reasoning"`
+	Queries    []string `json:"queries"`
+	Reasoning  string   `json:"reasoning"`
 	TimeFilter *struct {
 		Start string `json:"start"`
 		End   string `json:"end"`
@@ -328,26 +328,6 @@ func normalizeQueries(queries []string, previous []string) []string {
 		unique = append(unique, trimmed)
 	}
 	return unique
-}
-
-func uniqueStrings(values []string) []string {
-	if len(values) == 0 {
-		return nil
-	}
-	seen := make(map[string]struct{}, len(values))
-	result := make([]string, 0, len(values))
-	for _, v := range values {
-		key := strings.ToLower(strings.TrimSpace(v))
-		if key == "" {
-			continue
-		}
-		if _, exists := seen[key]; exists {
-			continue
-		}
-		seen[key] = struct{}{}
-		result = append(result, key)
-	}
-	return result
 }
 
 func startOfDay(t time.Time) time.Time {


### PR DESCRIPTION
# Pull Request

## Summary
URL検索（term query）のフィールド名を修正し、`reference` フィールドを直接参照するように変更しました。

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Changes Made
- `internal/opensearch/hybrid_engine.go`: term queryのフィールド名を `reference.keyword` から `reference` に修正
- `cmd/mcp-server.go`: 未使用の `slack_channels` パラメータを削除

## Motivation and Context
URLを含むクエリを検索する際、term queryが `reference.keyword` フィールドを参照していましたが、OpenSearchのマッピングでは `reference` フィールドが直接 `keyword` 型として定義されています。そのため、URL検索が常に0件を返す問題が発生していました。

**問題の再現:**
```
URL detected in query: [https://hoge.kibe.la/notes/30119]
Executing term query on 'reference.keyword' field for 1 URL(s)
Term query completed in 6.93323ms, field=reference.keyword, hits=0
```

**修正後の期待動作:**
`reference` フィールドを直接参照することで、URLによるドキュメント検索が正常に動作するようになります。

## How Has This Been Tested?
- [x] Unit tests (`go test ./...`)
- [ ] Integration tests
- [x] Manual testing with local setup
- [ ] Tested with AWS services (S3 Vectors, OpenSearch, Bedrock)

### Test Configuration
- Go version: 1.23
- AWS Region: ap-northeast-1
- OpenSearch version: 2.x

## Impact Analysis
### Components Affected
- [ ] CLI commands (`cmd/`)
- [ ] Vectorization (`internal/vectorizer/`)
- [x] OpenSearch integration (`internal/opensearch/`)
- [ ] S3 Vector operations (`internal/s3vector/`)
- [ ] Slack bot (`internal/slackbot/`)
- [ ] Bedrock embedding (`internal/embedding/`)
- [ ] Configuration (`internal/config/`)

### AWS Resources Impact
- [x] No AWS resource changes
- [ ] S3 bucket operations
- [ ] OpenSearch index structure
- [ ] IAM permissions required
- [ ] Bedrock model usage

## Breaking Changes
- [x] None
- [ ] Yes (describe below)

## Dependencies
- [x] No new dependencies
- [ ] Dependencies added/updated (list below)

## Documentation
- [ ] README.md updated
- [ ] CLAUDE.md updated
- [ ] Inline code comments added/updated
- [ ] API documentation updated
- [ ] Configuration examples updated

## Checklist
- [x] My code follows the project's style guidelines (`go fmt ./...` and `go vet ./...`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have checked my code for any security issues or exposed secrets
- [ ] I have tested with the minimum supported Go version (1.23)
- [x] I have run `go mod tidy` to clean up dependencies

## Performance Considerations
- [x] No performance impact
- [ ] Performance improved (describe metrics)
- [ ] Performance degraded but acceptable (explain trade-offs)

## Additional Notes
OpenSearchのマッピングでは、`reference` フィールドは以下のように定義されています：
```json
"reference": {
  "type": "keyword",
  "fields": {
    "text": {
      "type": "text",
      "analyzer": "kuromoji"
    }
  }
}
```

この場合、`reference` フィールドが直接 `keyword` 型であり、`reference.keyword` というサブフィールドは存在しません。

---

# プルリクエスト（日本語版）

## 概要
URL検索（term query）のフィールド名を修正し、`reference` フィールドを直接参照するように変更しました。

## 変更の種類
- [x] バグ修正（既存機能を破壊しない問題の修正）

## 実装された変更
- term queryのフィールド名を `reference.keyword` から `reference` に修正
- 未使用の `slack_channels` パラメータをMCPツール定義から削除

## 動機と背景
URLを含むクエリでドキュメントが見つからない問題を修正。OpenSearchのマッピングと検索クエリのフィールド名が一致していなかったことが原因でした。
