### PR TITLE
feat: add author metadata support and improve CSV/vectorize pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ terraform/test/terraform.tfstate
 terraform/test/terraform.tfstate.backup
 terraform/test/terraform.tfvars
 terraform/aws/modules/ragent/.terraform
+csv-config.yaml
+*.db

--- a/internal/ingestion/csv/config.go
+++ b/internal/ingestion/csv/config.go
@@ -90,6 +90,9 @@ type MetadataMapping struct {
 
 	// Reference column name for reference information
 	Reference string `yaml:"reference"`
+
+	// Author column name for document author
+	Author string `yaml:"author"`
 }
 
 // LoadConfig loads and validates CSV configuration from a YAML file

--- a/internal/ingestion/csv/reader.go
+++ b/internal/ingestion/csv/reader.go
@@ -245,6 +245,11 @@ func extractMetadata(row []string, headers []string, detector *ColumnDetector, f
 		metadata.Reference = getColumnValue(row, headers, cfg.Reference)
 	}
 
+	// Author
+	if cfg.Author != "" {
+		metadata.Author = getColumnValue(row, headers, cfg.Author)
+	}
+
 	// CreatedAt
 	if cfg.CreatedAt != "" {
 		dateStr := getColumnValue(row, headers, cfg.CreatedAt)
@@ -263,6 +268,14 @@ func extractMetadata(row []string, headers []string, detector *ColumnDetector, f
 				metadata.UpdatedAt = parsedTime
 			}
 		}
+	}
+
+	now := time.Now()
+	if metadata.CreatedAt.IsZero() {
+		metadata.CreatedAt = now
+	}
+	if metadata.UpdatedAt.IsZero() {
+		metadata.UpdatedAt = now
 	}
 
 	return metadata
@@ -366,6 +379,17 @@ func sanitizeID(id string) string {
 	id = strings.ReplaceAll(id, "/", "_")
 	id = strings.ReplaceAll(id, "\\", "_")
 	return id
+}
+
+// ReadContent reads CSV content from a string and returns FileInfo slice (one per row).
+// This is used when the CSV content is already loaded (e.g., from S3 or GitHub sources).
+func (r *Reader) ReadContent(content string, sourcePath string) ([]*pkgdomain.FileInfo, error) {
+	fileConfig := r.config.GetConfigForFile(sourcePath)
+	if fileConfig == nil {
+		return nil, fmt.Errorf("no configuration found for CSV file: %s (no pattern matches)", sourcePath)
+	}
+
+	return r.readWithConfig(strings.NewReader(content), sourcePath, fileConfig)
 }
 
 // GetDetectedColumns returns information about detected columns for a CSV file

--- a/internal/ingestion/vectorizer/parallel_controller.go
+++ b/internal/ingestion/vectorizer/parallel_controller.go
@@ -207,10 +207,10 @@ func (pc *ParallelController) processFile(
 		fileInfo.Content = string(content)
 	}
 
-	// Extract metadata: skip for PDF files since pdf.Reader already sets correct metadata.
-	// Re-extracting with the page path (pdf://...pdf/page/N) would produce wrong values
-	// because filepath.Base() returns the page number instead of the original filename.
-	if !fileInfo.IsPDF {
+	// Skip metadata re-extraction for PDF and CSV files: their dedicated readers
+	// already set correct metadata. The generic extractor would overwrite those
+	// values with wrong path-derived defaults.
+	if !fileInfo.IsPDF && !fileInfo.IsCSV {
 		secret := fileInfo.Metadata.Secret
 		metadata, err := metadataExtractor.ExtractMetadata(fileInfo.Path, fileInfo.Content)
 		if err != nil {

--- a/internal/ingestion/vectorizer/service.go
+++ b/internal/ingestion/vectorizer/service.go
@@ -181,18 +181,7 @@ func (vs *VectorizerService) VectorizeMarkdownFiles(ctx context.Context, directo
 	}
 	log.Printf("Found %d files to process (%d markdown, %d CSV)", len(files), mdCount, csvCount)
 
-	// Expand CSV files into individual rows
-	expandedFiles, err := vs.expandCSVFiles(files)
-	if err != nil {
-		return nil, fmt.Errorf("failed to expand CSV files: %w", err)
-	}
-
-	// Expand PDF files into individual pages (handled in VectorizeFiles)
-	if len(expandedFiles) != len(files) {
-		log.Printf("After CSV expansion: %d total documents to process", len(expandedFiles))
-	}
-
-	return vs.VectorizeFiles(ctx, expandedFiles, dryRun)
+	return vs.VectorizeFiles(ctx, files, dryRun)
 }
 
 // expandCSVFiles expands CSV files into individual FileInfo entries (one per row)
@@ -201,16 +190,20 @@ func (vs *VectorizerService) expandCSVFiles(files []*pkgdomain.FileInfo) ([]*pkg
 
 	for _, file := range files {
 		if file.IsCSV {
-			// Expand CSV file into rows
 			log.Printf("Expanding CSV file: %s", file.Path)
-			csvFiles, err := vs.csvReader.ReadFile(file.Path)
+			var csvFiles []*pkgdomain.FileInfo
+			var err error
+			if file.Content != "" {
+				csvFiles, err = vs.csvReader.ReadContent(file.Content, file.Path)
+			} else {
+				csvFiles, err = vs.csvReader.ReadFile(file.Path)
+			}
 			if err != nil {
 				return nil, fmt.Errorf("failed to read CSV file %s: %w", file.Path, err)
 			}
 			log.Printf("  Expanded to %d rows", len(csvFiles))
 			result = append(result, csvFiles...)
 		} else {
-			// Keep markdown files as-is
 			result = append(result, file)
 		}
 	}
@@ -325,8 +318,18 @@ func (vs *VectorizerService) VectorizeFiles(ctx context.Context, files []*pkgdom
 
 	log.Printf("Processing %d files", len(files))
 
+	// Expand CSV files into individual rows (each row becomes a separate document)
+	expandedFiles, err := vs.expandCSVFiles(files)
+	if err != nil {
+		return nil, fmt.Errorf("failed to expand CSV files: %w", err)
+	}
+	if len(expandedFiles) != len(files) {
+		log.Printf("After CSV expansion: %d total documents to process", len(expandedFiles))
+	}
+	files = expandedFiles
+
 	// Expand PDF files into individual pages (for S3/GitHub sources with RawBytes, and local files)
-	expandedFiles, err := vs.expandPDFFiles(files)
+	expandedFiles, err = vs.expandPDFFiles(files)
 	if err != nil {
 		return nil, fmt.Errorf("failed to expand PDF files: %w", err)
 	}
@@ -362,10 +365,10 @@ func (vs *VectorizerService) ProcessSingleFile(ctx context.Context, fileInfo *pk
 		fileInfo.Content = content
 	}
 
-	// Extract metadata: skip for PDF files since pdf.Reader already sets correct metadata.
-	// Re-extracting with the page path (pdf://...pdf/page/N) would produce wrong values
-	// because filepath.Base() returns the page number instead of the original filename.
-	if !fileInfo.IsPDF {
+	// Skip metadata re-extraction for PDF and CSV files: their dedicated readers
+	// already set correct metadata. The generic extractor would overwrite those
+	// values with wrong path-derived defaults.
+	if !fileInfo.IsPDF && !fileInfo.IsCSV {
 		secret := fileInfo.Metadata.Secret
 		metadata, err := vs.metadataExtractor.ExtractMetadata(fileInfo.Path, fileInfo.Content)
 		if err != nil {

--- a/internal/mcpserver/hybrid_search_tool.go
+++ b/internal/mcpserver/hybrid_search_tool.go
@@ -655,6 +655,9 @@ func (hsta *HybridSearchToolAdapter) convertToMCPResponse(request *HybridSearchR
 		if category, ok := source["category"].(string); ok {
 			item.Category = category
 		}
+		if author, ok := source["author"].(string); ok {
+			item.Author = author
+		}
 		if createdAt, ok := source["created_at"].(string); ok {
 			item.CreatedAt = createdAt
 		}

--- a/internal/mcpserver/types.go
+++ b/internal/mcpserver/types.go
@@ -112,6 +112,7 @@ type HybridSearchResultItem struct {
 	Source    string                 `json:"source"` // "s3vector", "opensearch", "hybrid"
 	Path      string                 `json:"path"`   // File path
 	Category  string                 `json:"category,omitempty"`
+	Author    string                 `json:"author,omitempty"`
 	Tags      []string               `json:"tags,omitempty"`
 	CreatedAt string                 `json:"created_at,omitempty"`
 	UpdatedAt string                 `json:"updated_at,omitempty"`

--- a/internal/pkg/opensearch/bm25.go
+++ b/internal/pkg/opensearch/bm25.go
@@ -70,7 +70,7 @@ func (c *Client) SearchBM25(ctx context.Context, indexName string, query *BM25Qu
 		query.Size = 1000
 	}
 	if len(query.Fields) == 0 {
-		query.Fields = []string{"title", "content", "body"}
+		query.Fields = []string{"title", "content", "body", "author"}
 	}
 
 	startTime := time.Now()

--- a/internal/pkg/opensearch/hybrid_engine.go
+++ b/internal/pkg/opensearch/hybrid_engine.go
@@ -356,7 +356,7 @@ func (hse *HybridSearchEngine) validateQuery(query *HybridQuery) error {
 	}
 
 	if len(query.Fields) == 0 {
-		query.Fields = []string{"title", "content", "body"}
+		query.Fields = []string{"title", "content", "body", "author"}
 	}
 
 	if query.BM25Weight == 0 && query.VectorWeight == 0 {

--- a/internal/query/search/hybrid_service.go
+++ b/internal/query/search/hybrid_service.go
@@ -265,7 +265,8 @@ func (s *HybridSearchService) Search(ctx context.Context, request *SearchRequest
 				continue
 			}
 			if content, ok := source["content"].(string); ok && content != "" {
-				resp.ContextParts = append(resp.ContextParts, content)
+				contextText := buildContextText(source, content)
+				resp.ContextParts = append(resp.ContextParts, contextText)
 			}
 			var title, reference string
 			if t, ok := source["title"].(string); ok {
@@ -494,6 +495,23 @@ func (s *HybridSearchService) GetHybridEngine() *opensearch.HybridSearchEngine {
 }
 
 // HealthCheck checks if the service and its dependencies are healthy
+func buildContextText(source map[string]interface{}, content string) string {
+	var header strings.Builder
+	if title, ok := source["title"].(string); ok && title != "" {
+		fmt.Fprintf(&header, "タイトル: %s\n", title)
+	}
+	if author, ok := source["author"].(string); ok && author != "" {
+		fmt.Fprintf(&header, "著者: %s\n", author)
+	}
+	if category, ok := source["category"].(string); ok && category != "" {
+		fmt.Fprintf(&header, "カテゴリ: %s\n", category)
+	}
+	if header.Len() == 0 {
+		return content
+	}
+	return header.String() + "\n" + content
+}
+
 func (s *HybridSearchService) HealthCheck(ctx context.Context) error {
 	if s.osClient == nil {
 		return fmt.Errorf("OpenSearch client not initialized")


### PR DESCRIPTION
# Pull Request

## Summary

Add `author` metadata support across the entire pipeline (CSV config → metadata extraction → search → MCP response → chat context) and fix CSV file handling for S3/GitHub sources.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **Author metadata field**: Added `author` to CSV `MetadataMapping`, BM25 search fields, hybrid search fields, `HybridSearchResultItem`, and MCP response conversion
- **CSV metadata preservation**: Skip generic metadata extraction for CSV files (matching existing PDF behavior) so CSV-reader-provided metadata isn't overwritten by path-derived defaults
- **CSV expansion refactored**: Moved CSV row expansion from `VectorizeMarkdownFiles` to `VectorizeFiles` so S3/GitHub sources with pre-loaded content are expanded correctly
- **ReadContent method**: New `ReadContent(content string, sourcePath string)` method on CSV Reader to process CSV data from memory instead of disk
- **Default timestamps**: Set `CreatedAt`/`UpdatedAt` to current time when empty in CSV metadata extraction
- **Rich context text**: `buildContextText()` prepends title/author/category headers to content before passing to chat, making RAG responses more informative
- **.gitignore**: Added `csv-config.yaml` and `*.db`

## Motivation and Context

CSV files ingested from S3 or GitHub sources were not expanded into per-row documents because `VectorizeMarkdownFiles` called `expandCSVFiles` before `VectorizeFiles`, where S3 content gets loaded. Moving expansion into `VectorizeFiles` ensures content is available first.

The `author` field was missing from the metadata pipeline despite being valuable for search relevance and context quality. BM25 and hybrid search now index and query the `author` field, and chat/query responses include author information in their context.

## How Has This Been Tested?

- [x] Unit tests (`go test ./...`)
- [x] Manual testing with local setup
- [ ] Integration tests
- [ ] Tested with AWS services (S3 Vectors, OpenSearch, Bedrock)

### Test Configuration

- Go version: 1.24
- AWS Region: N/A (local)

## Impact Analysis

### Components Affected

- [x] Vectorization (`internal/vectorizer/`)
- [x] OpenSearch integration (`internal/opensearch/`)
- [ ] S3 Vector operations (`internal/s3vector/`)
- [ ] Slack bot (`internal/slackbot/`)
- [ ] Bedrock embedding (`internal/embedding/`)
- [ ] CLI commands (`cmd/`)
- [x] MCP Server (`internal/mcpserver/`)
- [x] Query/Chat (`internal/query/`)
- [x] CSV ingestion (`internal/csv/`)

### AWS Resources Impact

- [x] No AWS resource changes
- [ ] S3 bucket operations
- [ ] OpenSearch index structure
- [ ] IAM permissions required
- [ ] Bedrock model usage

## Breaking Changes

- [x] None
- [ ] Yes (describe below)

### Migration Guide

N/A — the `author` field is optional (`omitempty`). Existing CSV configs without an `author` mapping continue to work unchanged.

## Dependencies

- [x] No new dependencies
- [ ] Dependencies added/updated (list below)

## Documentation

- [ ] README.md updated
- [ ] CLAUDE.md updated
- [x] Inline code comments added/updated
- [ ] API documentation updated
- [ ] Configuration examples updated

## Checklist

- [x] My code follows the project's style guidelines (`go fmt ./...` and `go vet ./...`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have checked my code for any security issues or exposed secrets
- [ ] I have tested with the minimum supported Go version (1.23)
- [x] I have run `go mod tidy` to clean up dependencies

## Performance Considerations

- [x] No performance impact
- [ ] Performance improved (describe metrics)
- [ ] Performance degraded but acceptable (explain trade-offs)

## Additional Notes

The `author` field in BM25/hybrid search default fields means author names are now full-text searchable alongside title, content, and body. This improves discoverability when users search by person name.

The `buildContextText` function uses Japanese labels (タイトル/著者/カテゴリ) matching the project's primary user base, producing richer RAG context without changing the stored content.

---

# プルリクエスト（日本語版）

## 概要

パイプライン全体（CSV設定 → メタデータ抽出 → 検索 → MCP レスポンス → チャットコンテキスト）に `author` メタデータサポートを追加し、S3/GitHub ソース向けの CSV ファイル処理を修正。

## 変更の種類

- [x] 新機能（既存機能を破壊しない機能の追加）
- [x] バグ修正（既存機能を破壊しない問題の修正）

## 実装された変更

- **author メタデータフィールド**: CSV `MetadataMapping`、BM25 検索フィールド、ハイブリッド検索フィールド、`HybridSearchResultItem`、MCP レスポンス変換に `author` を追加
- **CSV メタデータ保持**: CSV ファイルの汎用メタデータ抽出をスキップ（PDF と同様の既存動作）し、CSV リーダーが設定したメタデータがパス由来のデフォルト値で上書きされないよう修正
- **CSV 展開のリファクタリング**: CSV行展開を `VectorizeMarkdownFiles` から `VectorizeFiles` に移動し、S3/GitHub ソースの事前読み込みコンテンツが正しく展開されるよう修正
- **ReadContent メソッド**: CSV Reader にディスク而非メモリから CSV データを処理する `ReadContent` メソッドを追加
- **デフォルトタイムスタンプ**: CSV メタデータ抽出で `CreatedAt`/`UpdatedAt` が空の場合に現在時刻を設定
- **リッチコンテキストテキスト**: `buildContextText()` がタイトル/著者/カテゴリのヘッダーをコンテンツの前に付与し、RAG 応答をより情報豊かに改善
- **.gitignore**: `csv-config.yaml` と `*.db` を追加

## 動機と背景

S3/GitHub ソースから取り込んだ CSV ファイルは、`VectorizeMarkdownFiles` がコンテンツ読み込み前の `VectorizeFiles` で `expandCSVFiles` を呼び出していたため、行単位のドキュメントに展開されていませんでした。展開を `VectorizeFiles` 内に移動することで、コンテンツが先に利用可能になります。

`author` フィールドは検索の関連性とコンテキスト品質に有用ながら、メタデータパイプラインに欠けていました。BM25 とハイブリッド検索は author フィールドをインデックス・クエリ対象とし、チャット/クエリ応答に著者情報を含むようになります。

## テスト方法

- [x] ユニットテスト（`go test ./...`）
- [x] ローカル環境での手動テスト
- [ ] 統合テスト
- [ ] AWSサービス（S3 Vectors、OpenSearch、Bedrock）でのテスト

### テスト設定

- Goバージョン: 1.24
- AWSリージョン: N/A（ローカル）

## 影響分析

### 影響を受けるコンポーネント

- [x] ベクトル化（`internal/vectorizer/`）
- [x] OpenSearch統合（`internal/opensearch/`）
- [ ] S3 Vector操作（`internal/s3vector/`）
- [ ] Slack bot（`internal/slackbot/`）
- [ ] Bedrock埋め込み（`internal/embedding/`）
- [ ] CLIコマンド（`cmd/`）
- [x] MCP Server（`internal/mcpserver/`）
- [x] Query/Chat（`internal/query/`）
- [x] CSV インジェスト（`internal/csv/`）

### AWSリソースへの影響

- [x] AWSリソースの変更なし
- [ ] S3バケット操作
- [ ] OpenSearchインデックス構造
- [ ] IAM権限が必要
- [ ] Bedrockモデルの使用

## 破壊的変更

- [x] なし
- [ ] あり（以下に記述）

### 移行ガイド

N/A — `author` フィールドはオプショナル（`omitempty`）です。`author` マッピングのない既存の CSV 設定はそのまま動作します。

## 依存関係

- [x] 新しい依存関係なし
- [ ] 依存関係の追加/更新（以下にリスト）

## ドキュメント

- [ ] README.md更新
- [ ] CLAUDE.md更新
- [x] インラインコードコメントの追加/更新
- [ ] APIドキュメント更新
- [ ] 設定例の更新

## チェックリスト

- [x] コードがプロジェクトのスタイルガイドラインに従っている（`go fmt ./...` と `go vet ./...`）
- [x] 自分のコードをセルフレビューした
- [x] 理解が困難な領域にコメントを追加した
- [ ] ドキュメントに対応する変更を行った
- [x] 変更によって新しい警告やエラーが生成されない
- [ ] 修正が効果的であることまたは機能が動作することを証明するテストを追加した
- [x] 新しいテストと既存のユニットテストがローカルで成功する
- [ ] 依存する変更がマージされ公開されている
- [x] セキュリティ問題や露出した秘密情報がないかコードをチェックした
- [ ] サポートされる最小Goバージョン（1.23）でテストした
- [x] `go mod tidy`を実行して依存関係をクリーンアップした

## パフォーマンスに関する考慮事項

- [x] パフォーマンスへの影響なし

## 追加ノート

BM25/ハイブリッド検索のデフォルトフィールドに `author` を追加したことで、著者名が title、content、body と同じく全文検索対象となりました。ユーザーが人名で検索した際の発見性が向上します。

`buildContextText` 関数はプロジェクトの主要ユーザーベースに合わせて日本語ラベル（タイトル/著者/カテゴリ）を使用し、保存済みコンテンツを変更せずに RAG コンテキストをより情報豊かにします。