### PR TITLE
fix: strip embedding fields from search responses

### DIFF
--- a/internal/mcpserver/hybrid_search_tool.go
+++ b/internal/mcpserver/hybrid_search_tool.go
@@ -15,6 +15,16 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 )
 
+// sourceExcludeFields lists fields that must never appear in MCP tool responses.
+var sourceExcludeFields = []string{"embedding"}
+
+// sanitizeSourceFields removes fields that should never be exposed in MCP responses.
+func sanitizeSourceFields(source map[string]interface{}) {
+	for _, field := range sourceExcludeFields {
+		delete(source, field)
+	}
+}
+
 type SearchClient interface {
 	opensearch.SearchClient
 	HealthCheck(ctx context.Context) error
@@ -676,8 +686,9 @@ func (hsta *HybridSearchToolAdapter) convertToMCPResponse(request *HybridSearchR
 			}
 		}
 
-		// Include metadata if requested
+		// Include metadata if requested (with sensitive fields stripped)
 		if request.IncludeMetadata {
+			sanitizeSourceFields(source)
 			item.Metadata = source
 		}
 

--- a/internal/mcpserver/sanitize_source_test.go
+++ b/internal/mcpserver/sanitize_source_test.go
@@ -1,0 +1,124 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ca-srg/ragent/internal/pkg/opensearch"
+)
+
+func TestSanitizeSourceFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   map[string]interface{}
+		wantKeys []string
+	}{
+		{
+			name: "removes embedding when present",
+			source: map[string]interface{}{
+				"title":     "doc1",
+				"content":   "hello",
+				"embedding": []float64{0.1, 0.2, 0.3},
+			},
+			wantKeys: []string{"title", "content"},
+		},
+		{
+			name: "no-op when embedding absent",
+			source: map[string]interface{}{
+				"title":   "doc2",
+				"content": "world",
+			},
+			wantKeys: []string{"title", "content"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sanitizeSourceFields(tt.source)
+
+			if _, ok := tt.source["embedding"]; ok {
+				t.Fatalf("embedding should have been removed")
+			}
+
+			for _, key := range tt.wantKeys {
+				if _, ok := tt.source[key]; !ok {
+					t.Fatalf("expected key %q to be present", key)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeSourceFieldsPreservesOtherFields(t *testing.T) {
+	source := map[string]interface{}{
+		"title":     "Document Title",
+		"content":   "Document content",
+		"category":  "tech",
+		"tags":      []string{"go", "search"},
+		"reference": "https://example.com",
+		"secret":    false,
+		"embedding": []float64{0.1, 0.2},
+	}
+
+	sanitizeSourceFields(source)
+
+	if _, ok := source["embedding"]; ok {
+		t.Fatalf("embedding should have been removed")
+	}
+
+	preserved := []string{"title", "content", "category", "tags", "reference", "secret"}
+	for _, key := range preserved {
+		if _, ok := source[key]; !ok {
+			t.Fatalf("expected field %q to be preserved", key)
+		}
+	}
+}
+
+func TestConvertToMCPResponseStripsEmbedding(t *testing.T) {
+	adapter := &HybridSearchToolAdapter{}
+
+	// Create a document with embedding in its source JSON
+	sourceJSON := `{"title":"Test Doc","content":"Hello world","embedding":[0.1,0.2,0.3],"category":"tech"}`
+
+	request := &HybridSearchRequest{
+		Query:           "test",
+		IncludeMetadata: true,
+	}
+
+	result := &opensearch.HybridSearchResult{
+		FusionResult: &opensearch.FusionResult{
+			Documents: []opensearch.ScoredDoc{
+				{
+					ID:         "doc-1",
+					FusedScore: 0.95,
+					Source:     json.RawMessage(sourceJSON),
+				},
+			},
+			TotalHits: 1,
+		},
+	}
+
+	response := adapter.convertToMCPResponse(request, result, nil, nil)
+
+	if len(response.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(response.Results))
+	}
+
+	metadata := response.Results[0].Metadata
+	if metadata == nil {
+		t.Fatalf("expected metadata to be present when IncludeMetadata=true")
+	}
+
+	// embedding should be stripped
+	if _, ok := metadata["embedding"]; ok {
+		t.Fatalf("embedding should have been stripped from metadata")
+	}
+
+	// other fields should be preserved
+	if title, ok := metadata["title"].(string); !ok || title != "Test Doc" {
+		t.Fatalf("expected title to be preserved, got %v", metadata["title"])
+	}
+	if category, ok := metadata["category"].(string); !ok || category != "tech" {
+		t.Fatalf("expected category to be preserved, got %v", metadata["category"])
+	}
+}

--- a/internal/pkg/opensearch/bm25.go
+++ b/internal/pkg/opensearch/bm25.go
@@ -197,6 +197,9 @@ func (c *Client) buildBM25SearchBody(query *BM25Query) map[string]interface{} {
 	}
 
 	applySecretExclusion(boolQuery, query.ExcludeSecret)
+	body["_source"] = map[string]interface{}{
+		"excludes": []string{"embedding"},
+	}
 
 	return body
 }

--- a/internal/pkg/opensearch/bm25_test.go
+++ b/internal/pkg/opensearch/bm25_test.go
@@ -148,3 +148,27 @@ func TestBuildBM25SearchBodyDoesNotAddSecretClauseWhenDisabled(t *testing.T) {
 		t.Fatalf("did not expect must_not clause when secret exclusion disabled")
 	}
 }
+
+func TestBuildBM25SearchBodyExcludesEmbedding(t *testing.T) {
+	client := &Client{}
+	query := &BM25Query{
+		Query:  "hello",
+		Fields: []string{"title", "content"},
+		Size:   10,
+	}
+
+	body := client.buildBM25SearchBody(query)
+	source, ok := body["_source"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected _source section")
+	}
+
+	excludes, ok := source["excludes"].([]string)
+	if !ok {
+		t.Fatalf("expected excludes to be []string")
+	}
+
+	if len(excludes) != 1 || excludes[0] != "embedding" {
+		t.Fatalf("expected excludes to contain embedding, got %#v", excludes)
+	}
+}

--- a/internal/pkg/opensearch/client.go
+++ b/internal/pkg/opensearch/client.go
@@ -344,6 +344,9 @@ func BuildTermQueryBody(query *TermQuery) map[string]interface{} {
 			"bool": boolQuery,
 		}
 	}
+	body["_source"] = map[string]interface{}{
+		"excludes": []string{"embedding"},
+	}
 
 	return body
 }

--- a/internal/pkg/opensearch/vector.go
+++ b/internal/pkg/opensearch/vector.go
@@ -214,6 +214,9 @@ func (c *Client) buildVectorSearchBody(query *VectorQuery) map[string]interface{
 			applySecretExclusion(boolClause, true)
 		}
 	}
+	body["_source"] = map[string]interface{}{
+		"excludes": []string{"embedding"},
+	}
 
 	return body
 }

--- a/internal/pkg/opensearch/vector_test.go
+++ b/internal/pkg/opensearch/vector_test.go
@@ -1,0 +1,28 @@
+package opensearch
+
+import "testing"
+
+func TestBuildVectorSearchBodyExcludesEmbedding(t *testing.T) {
+	client := &Client{}
+	query := &VectorQuery{
+		VectorField: "embedding",
+		Vector:      []float64{0.1, 0.2, 0.3},
+		K:           5,
+		Size:        3,
+	}
+
+	body := client.buildVectorSearchBody(query)
+	source, ok := body["_source"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected _source section")
+	}
+
+	excludes, ok := source["excludes"].([]string)
+	if !ok {
+		t.Fatalf("expected excludes to be []string")
+	}
+
+	if len(excludes) != 1 || excludes[0] != "embedding" {
+		t.Fatalf("expected excludes to contain embedding, got %#v", excludes)
+	}
+}

--- a/tests/unit/term_query_test.go
+++ b/tests/unit/term_query_test.go
@@ -22,6 +22,9 @@ func TestBuildTermQueryBody(t *testing.T) {
 	expectedSingle := map[string]interface{}{
 		"size": float64(5),
 		"from": float64(0),
+		"_source": map[string]interface{}{
+			"excludes": []interface{}{"embedding"},
+		},
 		"query": map[string]interface{}{
 			"terms": map[string]interface{}{
 				"reference": []interface{}{"https://example.com"},
@@ -40,6 +43,9 @@ func TestBuildTermQueryBody(t *testing.T) {
 	expectedMultiple := map[string]interface{}{
 		"size": float64(10),
 		"from": float64(2),
+		"_source": map[string]interface{}{
+			"excludes": []interface{}{"embedding"},
+		},
 		"query": map[string]interface{}{
 			"terms": map[string]interface{}{
 				"reference": []interface{}{"https://example.com", "http://test.com"},
@@ -83,6 +89,31 @@ func TestBuildTermQueryResponse(t *testing.T) {
 			assert.Equal(t, json.RawMessage(`{"reference":"https://example.com"}`), result.Results[0].Source)
 		}
 	}
+}
+
+func TestBuildTermQueryBodyExcludesEmbedding(t *testing.T) {
+	t.Parallel()
+
+	query := &opensearch.TermQuery{
+		Field:  "reference",
+		Values: []string{"https://example.com"},
+		Size:   5,
+	}
+	body := opensearch.BuildTermQueryBody(query)
+	expected := map[string]interface{}{
+		"size": float64(5),
+		"from": float64(0),
+		"query": map[string]interface{}{
+			"terms": map[string]interface{}{
+				"reference": []interface{}{"https://example.com"},
+			},
+		},
+		"_source": map[string]interface{}{
+			"excludes": []interface{}{"embedding"},
+		},
+	}
+
+	assert.Equal(t, expected, normalize(body))
 }
 
 func normalize(body map[string]interface{}) map[string]interface{} {


### PR DESCRIPTION
# Pull Request

## Summary
Prevent OpenSearch and MCP responses from exposing `embedding` vectors in returned source metadata.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Changes Made
- Excluded `embedding` from BM25 and vector search `_source` payloads.
- Excluded `embedding` from term query `_source` payloads.
- Added MCP-side sanitization so `include_metadata=true` never returns `embedding`.

## Motivation and Context
Search responses do not need to expose raw vector payloads, and returning them increases response size while leaking internal indexing details.

## How Has This Been Tested?
- [x] Unit tests (`go test ./...`)
- [ ] Integration tests
- [ ] Manual testing with local setup
- [ ] Tested with AWS services (S3 Vectors, OpenSearch, Bedrock)

### Test Configuration
- Go version: go1.26.0 darwin/arm64
- AWS Region: N/A
- OpenSearch version (if applicable): N/A

Executed:
- `go test ./internal/pkg/opensearch -timeout 120s`
- `go test ./internal/mcpserver -timeout 120s`
- `go test ./tests/unit/... -timeout 120s`

## Impact Analysis
### Components Affected
- [ ] CLI commands (`cmd/`)
- [ ] Vectorization (`internal/vectorizer/`)
- [x] OpenSearch integration (`internal/opensearch/`)
- [ ] S3 Vector operations (`internal/s3vector/`)
- [ ] Slack bot (`internal/slackbot/`)
- [ ] Bedrock embedding (`internal/embedding/`)
- [ ] Configuration (`internal/config/`)

Additional affected slice:
- [x] MCP server (`internal/mcpserver/`)

### AWS Resources Impact
- [x] No AWS resource changes
- [ ] S3 bucket operations
- [ ] OpenSearch index structure
- [ ] IAM permissions required
- [ ] Bedrock model usage

## Breaking Changes
- [x] None
- [ ] Yes (describe below)

### Migration Guide
Not required.

## Dependencies
- [x] No new dependencies
- [ ] Dependencies added/updated (list below)

## Documentation
- [ ] README.md updated
- [ ] CLAUDE.md updated
- [ ] Inline code comments added/updated
- [ ] API documentation updated
- [ ] Configuration examples updated

## Checklist
- [x] My code follows the project's style guidelines (`go fmt ./...` and `go vet ./...`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have checked my code for any security issues or exposed secrets
- [ ] I have tested with the minimum supported Go version (1.23)
- [ ] I have run `go mod tidy` to clean up dependencies

## Performance Considerations
- [x] No performance impact
- [ ] Performance improved (describe metrics)
- [ ] Performance degraded but acceptable (explain trade-offs)

## Additional Notes
This change adds exclusion at both query-construction time and MCP response-construction time so the protection holds even if one layer changes later.

## Screenshots/Logs
N/A

---

# プルリクエスト（日本語版）

## 概要
OpenSearch および MCP のレスポンスに `embedding` ベクトルが含まれないようにし、不要な内部データの露出を防ぎます。

## 変更の種類
- [x] バグ修正（既存機能を破壊しない問題の修正）
- [ ] 新機能（既存機能を破壊しない機能の追加）
- [ ] 破壊的変更（既存機能の動作に影響を与える修正や機能）
- [ ] ドキュメント更新
- [ ] パフォーマンス改善
- [ ] リファクタリング（機能的変更なし）

## 実装された変更
- BM25 / vector 検索の `_source` から `embedding` を除外しました。
- term query の `_source` から `embedding` を除外しました。
- `include_metadata=true` の MCP レスポンスでも `embedding` を除去する防御を追加しました。

## 動機と背景
検索レスポンスで raw ベクトルを返す必要はなく、レスポンス肥大化と内部実装の露出につながるためです。

## テスト方法
- [x] ユニットテスト（`go test ./...`）
- [ ] 統合テスト
- [ ] ローカル環境での手動テスト
- [ ] AWSサービス（S3 Vectors、OpenSearch、Bedrock）でのテスト

### テスト設定
- Goバージョン: go1.26.0 darwin/arm64
- AWSリージョン: N/A
- OpenSearchバージョン（該当する場合）: N/A

実行コマンド:
- `go test ./internal/pkg/opensearch -timeout 120s`
- `go test ./internal/mcpserver -timeout 120s`
- `go test ./tests/unit/... -timeout 120s`

## 影響分析
### 影響を受けるコンポーネント
- [ ] CLIコマンド（`cmd/`）
- [ ] ベクトル化（`internal/vectorizer/`）
- [x] OpenSearch統合（`internal/opensearch/`）
- [ ] S3 Vector操作（`internal/s3vector/`）
- [ ] Slack bot（`internal/slackbot/`）
- [ ] Bedrock埋め込み（`internal/embedding/`）
- [ ] 設定（`internal/config/`）

追加影響:
- [x] MCP server（`internal/mcpserver/`）

### AWSリソースへの影響
- [x] AWSリソースの変更なし
- [ ] S3バケット操作
- [ ] OpenSearchインデックス構造
- [ ] IAM権限が必要
- [ ] Bedrockモデルの使用

## 破壊的変更
- [x] なし
- [ ] あり（以下に記述）

### 移行ガイド
不要です。

## 依存関係
- [x] 新しい依存関係なし
- [ ] 依存関係の追加/更新（以下にリスト）

## ドキュメント
- [ ] README.md更新
- [ ] CLAUDE.md更新
- [ ] インラインコードコメントの追加/更新
- [ ] APIドキュメント更新
- [ ] 設定例の更新

## チェックリスト
- [x] コードがプロジェクトのスタイルガイドラインに従っている（`go fmt ./...` と `go vet ./...`）
- [x] 自分のコードをセルフレビューした
- [x] 理解が困難な領域にコメントを追加した
- [ ] ドキュメントに対応する変更を行った
- [x] 変更によって新しい警告やエラーが生成されない
- [x] 修正が効果的であることまたは機能が動作することを証明するテストを追加した
- [x] 新しいテストと既存のユニットテストがローカルで成功する
- [ ] 依存する変更がマージされ公開されている
- [x] セキュリティ問題や露出した秘密情報がないかコードをチェックした
- [ ] サポートされる最小Goバージョン（1.23）でテストした
- [ ] `go mod tidy`を実行して依存関係をクリーンアップした

## パフォーマンスに関する考慮事項
- [x] パフォーマンスへの影響なし
- [ ] パフォーマンス改善（メトリクスを記述）
- [ ] パフォーマンス低下だが許容範囲（トレードオフを説明）

## 追加ノート
クエリ生成時と MCP レスポンス生成時の両方で除外しているため、どちらか一方の層が今後変わっても防御が残る構成です。

## スクリーンショット/ログ
N/A
