### PR TITLE
fix(vectorizer): skip CSV files without matching csv-config instead of aborting the cycle

### DIFF
--- a/internal/ingestion/csv/errors.go
+++ b/internal/ingestion/csv/errors.go
@@ -1,0 +1,9 @@
+package csv
+
+import "errors"
+
+// ErrNoCSVConfig indicates that none of the configured patterns matched a
+// given CSV file path. Callers that process multiple files in a pipeline
+// should typically log a warning and skip the offending file via
+// errors.Is(err, ErrNoCSVConfig), instead of failing the whole batch.
+var ErrNoCSVConfig = errors.New("no configuration found for CSV file (no pattern matches)")

--- a/internal/ingestion/csv/reader.go
+++ b/internal/ingestion/csv/reader.go
@@ -32,7 +32,7 @@ func (r *Reader) ReadFile(filePath string) ([]*pkgdomain.FileInfo, error) {
 	// Get configuration for this file
 	fileConfig := r.config.GetConfigForFile(filePath)
 	if fileConfig == nil {
-		return nil, fmt.Errorf("no configuration found for CSV file: %s (no pattern matches)", filePath)
+		return nil, fmt.Errorf("%w: %s", ErrNoCSVConfig, filePath)
 	}
 
 	file, err := os.Open(filePath)
@@ -386,7 +386,7 @@ func sanitizeID(id string) string {
 func (r *Reader) ReadContent(content string, sourcePath string) ([]*pkgdomain.FileInfo, error) {
 	fileConfig := r.config.GetConfigForFile(sourcePath)
 	if fileConfig == nil {
-		return nil, fmt.Errorf("no configuration found for CSV file: %s (no pattern matches)", sourcePath)
+		return nil, fmt.Errorf("%w: %s", ErrNoCSVConfig, sourcePath)
 	}
 
 	return r.readWithConfig(strings.NewReader(content), sourcePath, fileConfig)
@@ -398,7 +398,7 @@ func (r *Reader) GetDetectedColumns(filePath string) (*DetectedColumnsInfo, erro
 	// Get configuration for this file
 	fileConfig := r.config.GetConfigForFile(filePath)
 	if fileConfig == nil {
-		return nil, fmt.Errorf("no configuration found for CSV file: %s (no pattern matches)", filePath)
+		return nil, fmt.Errorf("%w: %s", ErrNoCSVConfig, filePath)
 	}
 
 	file, err := os.Open(filePath)
@@ -500,7 +500,7 @@ func (r *Reader) GetDetectedColumnsFromContent(filePath string, content string) 
 	// Get configuration for this file
 	fileConfig := r.config.GetConfigForFile(filePath)
 	if fileConfig == nil {
-		return nil, fmt.Errorf("no configuration found for CSV file: %s (no pattern matches)", filePath)
+		return nil, fmt.Errorf("%w: %s", ErrNoCSVConfig, filePath)
 	}
 
 	csvReader := csv.NewReader(strings.NewReader(content))

--- a/internal/ingestion/csv/reader_test.go
+++ b/internal/ingestion/csv/reader_test.go
@@ -1,6 +1,7 @@
 package csv
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -262,8 +263,11 @@ func TestReader_ReadFile_NoMatchingPattern(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for no matching pattern")
 	}
-	if !strings.Contains(err.Error(), "no configuration found") {
-		t.Errorf("expected 'no configuration found' error, got: %v", err)
+	if !errors.Is(err, ErrNoCSVConfig) {
+		t.Errorf("expected ErrNoCSVConfig, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), csvPath) {
+		t.Errorf("expected error to reference the file path %q, got: %v", csvPath, err)
 	}
 }
 

--- a/internal/ingestion/vectorizer/expand_csv_test.go
+++ b/internal/ingestion/vectorizer/expand_csv_test.go
@@ -1,0 +1,85 @@
+package vectorizer
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ca-srg/ragent/internal/ingestion/csv"
+	pkgdomain "github.com/ca-srg/ragent/internal/pkg/domain"
+)
+
+func newTestCSVReaderWithPattern(pattern string) *csv.Reader {
+	cfg := &csv.Config{
+		CSV: csv.CSVConfig{
+			Files: []csv.FileConfig{
+				{
+					Pattern: pattern,
+					Content: csv.ContentConfig{
+						Columns: []string{"content"},
+					},
+					Metadata: csv.MetadataMapping{
+						Title: "title",
+					},
+				},
+			},
+		},
+	}
+	return csv.NewReader(cfg)
+}
+
+func TestExpandCSVFiles_SkipsFilesWithoutMatchingConfig(t *testing.T) {
+	vs := &VectorizerService{csvReader: newTestCSVReaderWithPattern("matched*.csv")}
+
+	files := []*pkgdomain.FileInfo{
+		{Path: "matched-foo.csv", IsCSV: true, Content: "title,content\nhello,world\n"},
+		{Path: "unmatched-bar.csv", IsCSV: true, Content: "a,b\n1,2\n"},
+		{Path: "notes.md", IsCSV: false},
+	}
+
+	expanded, err := vs.expandCSVFiles(files)
+	require.NoError(t, err, "unmatched CSV must not fail the whole expansion")
+
+	var csvRows, passthrough int
+	for _, f := range expanded {
+		if f.IsCSV {
+			csvRows++
+		} else {
+			passthrough++
+		}
+	}
+	assert.Equal(t, 1, csvRows, "only matched-foo.csv row should be expanded")
+	assert.Equal(t, 1, passthrough, "markdown file should pass through")
+}
+
+func TestExpandCSVFiles_PropagatesNonConfigErrors(t *testing.T) {
+	vs := &VectorizerService{csvReader: newTestCSVReaderWithPattern("*.csv")}
+
+	// All-empty header row triggers the "invalid CSV header row" error inside
+	// readWithConfig, which is NOT ErrNoCSVConfig and therefore must propagate.
+	files := []*pkgdomain.FileInfo{
+		{Path: "broken.csv", IsCSV: true, Content: ",,,\n1,2,3\n"},
+	}
+
+	_, err := vs.expandCSVFiles(files)
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, csv.ErrNoCSVConfig),
+		"non-config errors must still propagate so callers can surface them")
+}
+
+func TestExpandCSVFiles_AllUnmatchedStillSucceeds(t *testing.T) {
+	vs := &VectorizerService{csvReader: newTestCSVReaderWithPattern("matched*.csv")}
+
+	files := []*pkgdomain.FileInfo{
+		{Path: "unmatched-a.csv", IsCSV: true, Content: "a\n1\n"},
+		{Path: "unmatched-b.csv", IsCSV: true, Content: "b\n2\n"},
+		{Path: "keep.md", IsCSV: false},
+	}
+
+	expanded, err := vs.expandCSVFiles(files)
+	require.NoError(t, err)
+	require.Len(t, expanded, 1)
+	assert.Equal(t, "keep.md", expanded[0].Path)
+}

--- a/internal/ingestion/vectorizer/service.go
+++ b/internal/ingestion/vectorizer/service.go
@@ -2,6 +2,7 @@ package vectorizer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -184,28 +185,42 @@ func (vs *VectorizerService) VectorizeMarkdownFiles(ctx context.Context, directo
 	return vs.VectorizeFiles(ctx, files, dryRun)
 }
 
-// expandCSVFiles expands CSV files into individual FileInfo entries (one per row)
+// expandCSVFiles expands CSV files into individual FileInfo entries (one per row).
+// CSV files without a matching csv-config entry are logged as a warning and
+// skipped so that a single misconfigured file does not fail the entire
+// vectorization cycle.
 func (vs *VectorizerService) expandCSVFiles(files []*pkgdomain.FileInfo) ([]*pkgdomain.FileInfo, error) {
 	var result []*pkgdomain.FileInfo
+	skipped := 0
 
 	for _, file := range files {
-		if file.IsCSV {
-			log.Printf("Expanding CSV file: %s", file.Path)
-			var csvFiles []*pkgdomain.FileInfo
-			var err error
-			if file.Content != "" {
-				csvFiles, err = vs.csvReader.ReadContent(file.Content, file.Path)
-			} else {
-				csvFiles, err = vs.csvReader.ReadFile(file.Path)
-			}
-			if err != nil {
-				return nil, fmt.Errorf("failed to read CSV file %s: %w", file.Path, err)
-			}
-			log.Printf("  Expanded to %d rows", len(csvFiles))
-			result = append(result, csvFiles...)
-		} else {
+		if !file.IsCSV {
 			result = append(result, file)
+			continue
 		}
+
+		log.Printf("Expanding CSV file: %s", file.Path)
+		var csvFiles []*pkgdomain.FileInfo
+		var err error
+		if file.Content != "" {
+			csvFiles, err = vs.csvReader.ReadContent(file.Content, file.Path)
+		} else {
+			csvFiles, err = vs.csvReader.ReadFile(file.Path)
+		}
+		if err != nil {
+			if errors.Is(err, csv.ErrNoCSVConfig) {
+				log.Printf("Warning: Skipping CSV file %s: no matching csv-config pattern (continuing)", file.Path)
+				skipped++
+				continue
+			}
+			return nil, fmt.Errorf("failed to read CSV file %s: %w", file.Path, err)
+		}
+		log.Printf("  Expanded to %d rows", len(csvFiles))
+		result = append(result, csvFiles...)
+	}
+
+	if skipped > 0 {
+		log.Printf("CSV expansion skipped %d file(s) without matching csv-config pattern", skipped)
 	}
 
 	return result, nil


### PR DESCRIPTION
## 概要

follow モードでの vectorize サイクルが、CSV ファイル 1 件の設定ミスで**毎回サイクル全体が失敗**し、新規/更新ファイル（Markdown 含む）が一切インデックスされない問題を修正。
## 原因

#59 (`18aefdf`) で導入された `VectorizerService.expandCSVFiles` は、`csvReader.Read{File,Content}` が返す「no pattern matches」エラーをそのまま上流に伝播させるため、バッチ全体が即時失敗する fail-fast になっていた。

## 変更点

- `internal/ingestion/csv/errors.go` に sentinel `ErrNoCSVConfig` を追加。
- `reader.go` の 4 箇所 (`ReadFile` / `ReadContent` / `GetDetectedColumns` / `GetDetectedColumnsFromContent`) の該当エラーを `fmt.Errorf(\"%w: %s\", ErrNoCSVConfig, path)` に書き換え。エラーメッセージはファイルパスを保持。
- `service.go` の `expandCSVFiles` に `errors.Is(err, csv.ErrNoCSVConfig)` の分岐を追加: 該当ファイルは `log.Printf(\"Warning: Skipping CSV file %s: ...\")` で skip し、サイクルは継続。他のエラー (IO / parse / invalid header 等) はこれまで通り propagate。skip 件数はサマリとして 1 行出力。
- テスト:
  - `reader_test.go` の `TestReader_ReadFile_NoMatchingPattern` を `errors.Is(err, ErrNoCSVConfig)` ベースに更新し、file path がエラーに含まれることもアサート。
  - `expand_csv_test.go` を新設し、(a) unmatched CSV が skip されマッチ分だけ expand される、(b) 非 `ErrNoCSVConfig` エラーは伝播、(c) 全件 unmatched でも markdown だけは通過、の 3 ケースを追加。

## 非目的

- 前回 PR の embedding 除外 fix (`f0b8154` / `f22c0ec` / `f16c55d`) は本問題とは無関係（検索レスポンス側の話）。

## 検証

- \`make lint\`: **0 issues**
- \`go test \$(go list ./... | grep -v '/tests/') -timeout 120s\`: all pass (vectorizer パッケージで warning ログ出力も確認)
- `TestExpandCSVFiles_SkipsFilesWithoutMatchingConfig` / `_PropagatesNonConfigErrors` / `_AllUnmatchedStillSucceeds` の 3 本追加、`TestReader_ReadFile_NoMatchingPattern` 更新、全て pass