### PR TITLE
fix(slackbot): prevent reply loops via event dedup and bot-origin filtering

### DIFF
--- a/internal/slackbot/bot.go
+++ b/internal/slackbot/bot.go
@@ -37,11 +37,13 @@ type Bot struct {
 	processor     *Processor
 	logger        *log.Logger
 	botUserID     string
+	botID         string
 	shutdownHooks []func()
 	enableThread  bool
 	rate          *RateLimiter
 	metrics       Metrics
 	reporter      ErrorReporter
+	dedup         *eventDedup
 }
 
 // NewBot constructs a Slack Bot
@@ -61,7 +63,9 @@ func NewBot(client SlackClient, processor *Processor, logger *log.Logger) (*Bot,
 		processor: processor,
 		logger:    logger,
 		botUserID: auth.UserID,
+		botID:     auth.BotID,
 		reporter:  &noopReporter{},
+		dedup:     newEventDedup(5*time.Minute, 4096),
 	}
 	// initialize RTM
 	rtm := client.NewRTM()
@@ -81,6 +85,7 @@ func NewBotWithRTM(client SlackClient, rtm RTMClient, processor *Processor, logg
 		logger:    logger,
 		botUserID: botUserID,
 		reporter:  &noopReporter{},
+		dedup:     newEventDedup(5*time.Minute, 4096),
 	}
 }
 
@@ -124,8 +129,20 @@ func (b *Bot) handleEvent(ctx context.Context, ev slack.RTMEvent) {
 		if data.SubType != "" { // ignore bot_message, message_changed, etc.
 			return
 		}
+		// Defense-in-depth: skip events authored by a bot (including ourselves).
+		if b.isBotOrigin(data.BotID, data.User) {
+			return
+		}
 		// gate: mention/DM + rate limit
 		if !b.processor.IsMentionOrDM(b.botUserID, data) {
+			return
+		}
+		// Dedup against duplicate RTM deliveries (e.g. reconnect backlog).
+		dedupKey := data.ClientMsgID
+		if dedupKey == "" {
+			dedupKey = "rtm:" + data.Channel + ":" + data.Timestamp
+		}
+		if b.dedup.markSeen(dedupKey) {
 			return
 		}
 		if b.rate != nil && !b.rate.Allow(data.User, data.Channel) {
@@ -191,3 +208,21 @@ func (w *rtmWrapper) Typing(channel string) { w.rtm.SendMessage(w.rtm.NewTypingM
 // Option setters
 func (b *Bot) SetEnableThreading(v bool)      { b.enableThread = v }
 func (b *Bot) SetRateLimiter(rl *RateLimiter) { b.rate = rl }
+
+// isBotOrigin reports whether an inbound message was authored by a bot
+// (including ourselves), so it should be ignored to prevent reply loops.
+func (b *Bot) isBotOrigin(botID, userID string) bool {
+	if botID != "" {
+		return true
+	}
+	if userID == "" {
+		return true
+	}
+	if userID == b.botUserID {
+		return true
+	}
+	if b.botID != "" && botID == b.botID {
+		return true
+	}
+	return false
+}

--- a/internal/slackbot/dedup.go
+++ b/internal/slackbot/dedup.go
@@ -1,0 +1,71 @@
+package slackbot
+
+import (
+	"sync"
+	"time"
+)
+
+// eventDedup keeps a TTL-bounded record of recently seen event keys so that
+// duplicate Slack event deliveries (e.g. Events API retries when an Ack is
+// not observed in time, or RTM reconnect backlogs) do not trigger the bot to
+// respond multiple times to the same user message.
+type eventDedup struct {
+	mu      sync.Mutex
+	seen    map[string]time.Time
+	ttl     time.Duration
+	maxSize int
+}
+
+// newEventDedup creates a dedup tracker. ttl controls how long a key is
+// considered seen; maxSize bounds the map to avoid unbounded growth.
+func newEventDedup(ttl time.Duration, maxSize int) *eventDedup {
+	if ttl <= 0 {
+		ttl = 5 * time.Minute
+	}
+	if maxSize <= 0 {
+		maxSize = 4096
+	}
+	return &eventDedup{
+		seen:    make(map[string]time.Time),
+		ttl:     ttl,
+		maxSize: maxSize,
+	}
+}
+
+// markSeen returns true if the key was already seen within the TTL window.
+// Otherwise it records the key and returns false.
+func (d *eventDedup) markSeen(key string) bool {
+	if d == nil || key == "" {
+		return false
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	now := time.Now()
+	if ts, ok := d.seen[key]; ok && now.Sub(ts) < d.ttl {
+		// refresh ttl so a hot key keeps being deduped
+		d.seen[key] = now
+		return true
+	}
+
+	// opportunistic GC: prune expired entries when we approach maxSize
+	if len(d.seen) >= d.maxSize {
+		for k, ts := range d.seen {
+			if now.Sub(ts) >= d.ttl {
+				delete(d.seen, k)
+			}
+		}
+		// if still too large after GC, drop arbitrary oldest-ish entries
+		if len(d.seen) >= d.maxSize {
+			for k := range d.seen {
+				delete(d.seen, k)
+				if len(d.seen) < d.maxSize {
+					break
+				}
+			}
+		}
+	}
+
+	d.seen[key] = now
+	return false
+}

--- a/internal/slackbot/dedup_test.go
+++ b/internal/slackbot/dedup_test.go
@@ -1,0 +1,86 @@
+package slackbot
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestEventDedup_FirstSeenReturnsFalse(t *testing.T) {
+	d := newEventDedup(time.Minute, 16)
+	if d.markSeen("evt-1") {
+		t.Fatalf("first occurrence should not be reported as seen")
+	}
+}
+
+func TestEventDedup_SecondSeenReturnsTrue(t *testing.T) {
+	d := newEventDedup(time.Minute, 16)
+	if d.markSeen("evt-1") {
+		t.Fatalf("first occurrence should not be reported as seen")
+	}
+	if !d.markSeen("evt-1") {
+		t.Fatalf("duplicate occurrence should be reported as seen")
+	}
+}
+
+func TestEventDedup_EmptyKeyIsNotDeduped(t *testing.T) {
+	d := newEventDedup(time.Minute, 16)
+	if d.markSeen("") {
+		t.Fatalf("empty key must never be considered duplicate")
+	}
+	if d.markSeen("") {
+		t.Fatalf("empty key must remain non-duplicate on repeat calls")
+	}
+}
+
+func TestEventDedup_NilReceiverIsSafe(t *testing.T) {
+	var d *eventDedup
+	if d.markSeen("anything") {
+		t.Fatalf("nil dedup must report not-seen, not crash")
+	}
+}
+
+func TestEventDedup_ExpiresAfterTTL(t *testing.T) {
+	d := newEventDedup(20*time.Millisecond, 16)
+	if d.markSeen("evt") {
+		t.Fatalf("first occurrence should not be seen")
+	}
+	time.Sleep(40 * time.Millisecond)
+	if d.markSeen("evt") {
+		t.Fatalf("entry should have expired after TTL")
+	}
+}
+
+func TestEventDedup_RespectsMaxSize(t *testing.T) {
+	d := newEventDedup(time.Minute, 8)
+	for i := 0; i < 32; i++ {
+		key := string(rune('a'+i%26)) + string(rune('0'+i%10))
+		d.markSeen(key)
+	}
+	d.mu.Lock()
+	size := len(d.seen)
+	d.mu.Unlock()
+	if size > 8 {
+		t.Fatalf("dedup map exceeded maxSize: got %d, want <=8", size)
+	}
+}
+
+func TestEventDedup_ConcurrentSafe(t *testing.T) {
+	d := newEventDedup(time.Minute, 1024)
+	var wg sync.WaitGroup
+	const workers = 16
+	const perWorker = 100
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				_ = d.markSeen("shared-key")
+			}
+		}(w)
+	}
+	wg.Wait()
+	if !d.markSeen("shared-key") {
+		t.Fatalf("after concurrent inserts the shared key should be marked seen")
+	}
+}

--- a/internal/slackbot/processor.go
+++ b/internal/slackbot/processor.go
@@ -55,8 +55,16 @@ func (p *Processor) ProcessMessage(ctx context.Context, botUserID string, msg *s
 	if msg == nil {
 		return nil
 	}
-	// Ignore messages from the bot itself
-	if msg.User == botUserID {
+	// Ignore messages from any bot (including ourselves) and synthetic events
+	// without an authoring user. This is a safety net in addition to the
+	// transport-level guards in Bot/SocketBot.
+	if msg.BotID != "" {
+		return nil
+	}
+	if msg.User == "" || msg.User == botUserID {
+		return nil
+	}
+	if msg.SubType == "bot_message" {
 		return nil
 	}
 

--- a/internal/slackbot/socketmode.go
+++ b/internal/slackbot/socketmode.go
@@ -20,10 +20,12 @@ type SocketBot struct {
 	processor    *Processor
 	logger       *log.Logger
 	botUserID    string
+	botID        string
 	enableThread bool
 	rate         *RateLimiter
 	metrics      Metrics
 	reporter     ErrorReporter
+	dedup        *eventDedup
 }
 
 // NewSocketBot constructs a Socket Mode Slack Bot
@@ -51,7 +53,9 @@ func NewSocketBot(client *slack.Client, appToken string, processor *Processor, l
 		processor: processor,
 		logger:    logger,
 		botUserID: auth.UserID,
+		botID:     auth.BotID,
 		reporter:  &noopReporter{},
+		dedup:     newEventDedup(5*time.Minute, 4096),
 	}, nil
 }
 
@@ -97,9 +101,13 @@ func (b *SocketBot) handleEvent(ctx context.Context, ev socketmode.Event) {
 	case socketmode.EventTypeIncomingError:
 		b.logger.Printf("incoming_error: %v", ev.Data)
 	case socketmode.EventTypeEventsAPI:
-		// Ack first to avoid retries
+		// Ack first to avoid Slack retries.
 		if ev.Request != nil {
 			b.sm.Ack(*ev.Request)
+			if ev.Request.RetryAttempt > 0 {
+				b.logger.Printf("event=events_api retry_attempt=%d retry_reason=%s envelope_id=%s",
+					ev.Request.RetryAttempt, ev.Request.RetryReason, ev.Request.EnvelopeID)
+			}
 		}
 		payload, ok := ev.Data.(slackevents.EventsAPIEvent)
 		if !ok {
@@ -108,9 +116,36 @@ func (b *SocketBot) handleEvent(ctx context.Context, ev socketmode.Event) {
 		if payload.Type != slackevents.CallbackEvent {
 			return
 		}
+
+		// Dedup: Slack may redeliver the same event_id when an Ack is not
+		// observed in time, when the websocket reconnects, or when multiple
+		// event subscriptions overlap. Process each event_id only once.
+		var eventID string
+		if cb, ok := payload.Data.(*slackevents.EventsAPICallbackEvent); ok && cb != nil {
+			eventID = cb.EventID
+		}
+		if eventID != "" {
+			if b.dedup.markSeen(eventID) {
+				b.logger.Printf("event=events_api status=duplicate event_id=%s", eventID)
+				return
+			}
+		}
+
 		inner := payload.InnerEvent
 		switch data := inner.Data.(type) {
 		case *slackevents.AppMentionEvent:
+			// Defense-in-depth: never react to events authored by a bot
+			// (including ourselves) so a stray mention echoed in our own
+			// reply cannot retrigger us.
+			if b.isBotOrigin(data.BotID, data.User) {
+				return
+			}
+			// Fallback dedup on channel:ts when event_id is missing.
+			if eventID == "" {
+				if b.dedup.markSeen("am:" + data.Channel + ":" + data.TimeStamp) {
+					return
+				}
+			}
 			msg := &slack.MessageEvent{
 				Msg: slack.Msg{
 					Channel:         data.Channel,
@@ -118,18 +153,26 @@ func (b *SocketBot) handleEvent(ctx context.Context, ev socketmode.Event) {
 					Text:            data.Text,
 					Timestamp:       data.TimeStamp,
 					ThreadTimestamp: data.ThreadTimeStamp,
+					BotID:           data.BotID,
 				},
 			}
 			b.processMessage(ctx, msg)
 		case *slackevents.MessageEvent:
-			// Only process user messages
+			// Only process plain user messages.
 			if data.SubType != "" { // ignore bot_message, message_changed, etc.
 				return
 			}
-			// Ignore message events in public channels to avoid duplicates with AppMentionEvent
-			// Only process DMs (Direct Messages) via MessageEvent
+			// Ignore non-DM message events to avoid duplicates with AppMentionEvent.
 			if !strings.HasPrefix(data.Channel, "D") {
 				return
+			}
+			if b.isBotOrigin(data.BotID, data.User) {
+				return
+			}
+			if eventID == "" {
+				if b.dedup.markSeen("msg:" + data.Channel + ":" + data.TimeStamp) {
+					return
+				}
 			}
 
 			msg := &slack.MessageEvent{
@@ -139,6 +182,7 @@ func (b *SocketBot) handleEvent(ctx context.Context, ev socketmode.Event) {
 					Text:            data.Text,
 					Timestamp:       data.TimeStamp,
 					ThreadTimestamp: data.ThreadTimeStamp,
+					BotID:           data.BotID,
 				},
 			}
 			b.processMessage(ctx, msg)
@@ -148,6 +192,25 @@ func (b *SocketBot) handleEvent(ctx context.Context, ev socketmode.Event) {
 	default:
 		// ignore
 	}
+}
+
+// isBotOrigin reports whether an inbound event was authored by a bot
+// (including ourselves). We must skip such events to avoid responding to our
+// own replies or to other bots' messages.
+func (b *SocketBot) isBotOrigin(botID, userID string) bool {
+	if botID != "" {
+		return true
+	}
+	if userID == "" {
+		return true
+	}
+	if userID == b.botUserID {
+		return true
+	}
+	if b.botID != "" && botID == b.botID {
+		return true
+	}
+	return false
 }
 
 func (b *SocketBot) processMessage(ctx context.Context, msg *slack.MessageEvent) {
@@ -171,7 +234,9 @@ func (b *SocketBot) processMessage(ctx context.Context, msg *slack.MessageEvent)
 		return
 	}
 	for _, opt := range reply.MsgOptions {
-		opt = slack.MsgOptionCompose(opt, slack.MsgOptionTS(threadTS))
+		if b.enableThread {
+			opt = slack.MsgOptionCompose(opt, slack.MsgOptionTS(threadTS))
+		}
 		if _, _, err := b.client.PostMessage(reply.Channel, opt); err != nil {
 			b.metrics.RecordError()
 			b.logger.Printf("event=post_message status=error err=%v", err)

--- a/internal/slackbot/thread_context.go
+++ b/internal/slackbot/thread_context.go
@@ -113,16 +113,14 @@ func (b *ThreadContextBuilder) formatThreadHistory(messages []slack.Message) str
 			continue
 		}
 
-		role := "ユーザー"
+		// Skip bot-authored messages entirely. Including our own past replies
+		// in the search query amplifies reply loops and rarely adds signal
+		// the user did not already provide.
 		if msg.BotID != "" || msg.SubType == "bot_message" || strings.EqualFold(msg.Username, "RAGent") {
-			role = "BOT"
-			if len([]rune(text)) > 200 {
-				text = string([]rune(text)[:200])
-			}
+			continue
 		}
 
-		buf.WriteString(role)
-		buf.WriteString(": ")
+		buf.WriteString("ユーザー: ")
 		buf.WriteString(text)
 		buf.WriteString("\n")
 	}

--- a/internal/slackbot/thread_context_test.go
+++ b/internal/slackbot/thread_context_test.go
@@ -33,12 +33,17 @@ func TestThreadContextBuilder_BuildFormatsHistory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	expected := "[過去の会話]\nユーザー: second message\nBOT: Thanks for the update.\n\n[現在の質問]\n" + current
+	// Bot-authored messages are intentionally excluded from history to
+	// prevent reply loops where the bot's own past output reseeds the query.
+	expected := "[過去の会話]\nユーザー: second message\n\n[現在の質問]\n" + current
 	if result != expected {
 		t.Fatalf("unexpected formatted result:\nwant: %q\ngot : %q", expected, result)
 	}
 	if strings.Contains(result, "first message") {
 		t.Fatalf("result should respect maxMessages limit: %s", result)
+	}
+	if strings.Contains(result, "Thanks for the update") {
+		t.Fatalf("bot-authored messages must be skipped: %s", result)
 	}
 }
 
@@ -121,12 +126,14 @@ func TestThreadContextBuilder_ReturnsCurrentQueryForEmptyThread(t *testing.T) {
 	}
 }
 
-func TestThreadContextBuilder_TruncatesBotMessages(t *testing.T) {
+func TestThreadContextBuilder_SkipsBotMessages(t *testing.T) {
 	longText := strings.Repeat("甲", 250)
 	mock := &mockSlackClient{
 		repliesFunc: func(params *slack.GetConversationRepliesParameters) ([]slack.Message, bool, string, error) {
 			return []slack.Message{
 				{Msg: slack.Msg{BotID: "B1", Text: longText}},
+				{Msg: slack.Msg{SubType: "bot_message", Text: "subtype bot reply"}},
+				{Msg: slack.Msg{Username: "RAGent", Text: "username bot reply"}},
 			}, false, "", nil
 		},
 	}
@@ -136,17 +143,21 @@ func TestThreadContextBuilder_TruncatesBotMessages(t *testing.T) {
 	}
 	builder := NewThreadContextBuilder(mock, cfg, log.New(io.Discard, "", 0))
 
-	current := "truncation test"
+	current := "skip-bot test"
 	result, err := builder.Build(context.Background(), "C1", "999", current)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	expectedBotText := strings.Repeat("甲", 200)
-	if !strings.Contains(result, "BOT: "+expectedBotText) {
-		t.Fatalf("expected truncated bot text (%d chars), got %q", len(expectedBotText), result)
+	// With only bot messages in the thread, history should be empty and the
+	// builder must return the current query unchanged.
+	if result != current {
+		t.Fatalf("expected current query when only bot messages exist, got %q", result)
 	}
-	if strings.Contains(result, strings.Repeat("甲", 201)) {
-		t.Fatalf("bot text should be truncated to 200 characters")
+	if strings.ContainsRune(result, '甲') {
+		t.Fatalf("bot text must not appear in history: %q", result)
+	}
+	if strings.Contains(result, "subtype bot reply") || strings.Contains(result, "username bot reply") {
+		t.Fatalf("bot-authored messages must be skipped: %q", result)
 	}
 }
 


### PR DESCRIPTION
# Pull Request

## Summary
Slackbot was replying repeatedly to the same user message. This PR closes two distinct loop sources at the transport layer and a third at the thread-context layer.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Changes Made
- New `internal/slackbot/dedup.go`: TTL-bounded, size-bounded, concurrency-safe `eventDedup` keyed on Slack `event_id` (with `channel:ts` fallback) and on RTM `client_msg_id` (with `channel:ts` fallback).
- `SocketBot` and `Bot` now reject events authored by any bot — `BotID != ""`, missing `user`, our own `botUserID`, or our own `bot_id` — before they reach the processor. `Processor.ProcessMessage` keeps the same guard as a safety net.
- Slack Events API retry deliveries are logged with `retry_attempt` and `retry_reason` for observability.
- `ThreadContextBuilder` skips bot-authored history entries entirely instead of truncating them, so the bot's own past replies cannot reseed a new query. Tests renamed from `TruncatesBotMessages` to `SkipsBotMessages` and updated.
- `SocketBot` now only forces `MsgOptionTS(threadTS)` when threading is enabled, matching the documented `enable_thread` option.

## Motivation and Context
Two reproducible loops were observed in production:
1. Slack redelivered the same `event_id` (Ack timeout, websocket reconnect, overlapping subscriptions). Each delivery produced a new reply.
2. The bot's own reply was being pulled back into the thread history and reseeded the next query, so even after the user stopped, the bot kept replying to itself.

The fix is defense-in-depth: dedup at the wire, bot-origin filtering at the dispatcher and processor, and exclusion of bot history at the context builder.

Fixes #(issue)

## How Has This Been Tested?
- [x] Unit tests (`go test ./internal/slackbot/... -timeout 60s`)
- [ ] Integration tests
- [ ] Manual testing with local setup
- [ ] Tested with AWS services (S3 Vectors, OpenSearch, Bedrock)

New tests:
- `TestEventDedup_FirstSeenReturnsFalse` / `TestEventDedup_SecondSeenReturnsTrue`
- `TestEventDedup_EmptyKeyIsNotDeduped`
- `TestEventDedup_NilReceiverIsSafe`
- `TestEventDedup_ExpiresAfterTTL`
- `TestEventDedup_RespectsMaxSize`
- `TestEventDedup_ConcurrentSafe`

Updated tests:
- `TestThreadContextBuilder_BuildFormatsHistory` now asserts bot lines are absent.
- `TestThreadContextBuilder_SkipsBotMessages` (renamed from `TruncatesBotMessages`) covers `BotID`, `SubType=bot_message`, and `Username=RAGent` paths.

### Test Configuration
- Go version: 1.23
- AWS Region: n/a
- OpenSearch version (if applicable): n/a

## Impact Analysis
### Components Affected
- [ ] CLI commands (`cmd/`)
- [ ] Vectorization (`internal/vectorizer/`)
- [ ] OpenSearch integration (`internal/opensearch/`)
- [ ] S3 Vector operations (`internal/s3vector/`)
- [x] Slack bot (`internal/slackbot/`)
- [ ] Bedrock embedding (`internal/embedding/`)
- [ ] Configuration (`internal/config/`)

### AWS Resources Impact
- [x] No AWS resource changes
- [ ] S3 bucket operations
- [ ] OpenSearch index structure
- [ ] IAM permissions required
- [ ] Bedrock model usage

## Breaking Changes
- [x] None
- [ ] Yes (describe below)

Behavioral note: bot-authored messages no longer appear in the formatted thread history that feeds the search query. This is intentional — including them was the loop amplifier — and the user-visible thread on Slack is unchanged.

## Dependencies
- [x] No new dependencies
- [ ] Dependencies added/updated (list below)

## Documentation
- [ ] README.md updated
- [ ] CLAUDE.md updated
- [x] Inline code comments added/updated
- [ ] API documentation updated
- [ ] Configuration examples updated

## Checklist
- [x] My code follows the project's style guidelines (`go fmt ./...` and `go vet ./...`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for any security issues or exposed secrets
- [x] I have tested with the minimum supported Go version (1.23)
- [ ] I have run `go mod tidy` to clean up dependencies

## Performance Considerations
- [x] No performance impact
- [ ] Performance improved (describe metrics)
- [ ] Performance degraded but acceptable (explain trade-offs)

The dedup map is bounded at 4096 entries per process with a 5-minute TTL and opportunistic GC, so memory is O(maxSize). Lookups are O(1) under a single mutex.

## Additional Notes
Dedup keys deliberately overlap (Events API uses `event_id`; RTM uses `client_msg_id`; both fall back to `channel:ts`) so any one transport quirk is caught by at least one layer.

## Screenshots/Logs
n/a

---

# プルリクエスト（日本語版）

## 概要
Slackbot が同一ユーザー発話に対して何度も返信してしまう不具合の修正。トランスポート層で重複イベントを抑止し、Bot 由来のイベント／履歴を除外することで二系統のループ要因を解消する。

## 変更の種類
- [x] バグ修正（既存機能を破壊しない問題の修正）
- [ ] 新機能（既存機能を破壊しない機能の追加）
- [ ] 破壊的変更（既存機能の動作に影響を与える修正や機能）
- [ ] ドキュメント更新
- [ ] パフォーマンス改善
- [ ] リファクタリング（機能的変更なし）

## 実装された変更
- `internal/slackbot/dedup.go` を新規追加。TTL とサイズで上限を持つ並行安全な `eventDedup`。`event_id`（フォールバック `channel:ts`）と RTM `client_msg_id`（フォールバック `channel:ts`）でキー化。
- `SocketBot` / `Bot` が Bot 由来イベント（`BotID` あり、`user` 空、自身の `botUserID`、自身の `bot_id`）を Processor へ到達する前に破棄。`Processor.ProcessMessage` にも保険として同等のガードを残す。
- Slack の retry 配信（`retry_attempt` / `retry_reason`）をログ出力し可観測性を確保。
- `ThreadContextBuilder` は Bot 発話を切り詰めるのではなく履歴から完全に除外。テストを `TruncatesBotMessages` → `SkipsBotMessages` に改名・更新。
- `SocketBot` はスレッド機能が有効な場合のみ `MsgOptionTS(threadTS)` を強制するよう修正（`enable_thread` 設定との整合）。

## 動機と背景
本番で再現した二つのループ要因：
1. Slack が同一 `event_id` を再配信（Ack タイムアウト、WebSocket 再接続、サブスクリプション重複）するたびに新しい返信が生成されていた。
2. Bot 自身の返信がスレッド履歴に取り込まれ、次回クエリの seed として再利用され、ユーザーが沈黙してもループが継続していた。

ワイヤ層での dedup、ディスパッチャと Processor での Bot 由来イベント除外、コンテキスト構築層での Bot 履歴除外、という多層防御で確実に断ち切る。

Fixes #(issue)

## テスト方法
- [x] ユニットテスト（`go test ./internal/slackbot/... -timeout 60s`）
- [ ] 統合テスト
- [ ] ローカル環境での手動テスト
- [ ] AWSサービス（S3 Vectors、OpenSearch、Bedrock）でのテスト

### テスト設定
- Goバージョン: 1.23
- AWSリージョン: n/a
- OpenSearchバージョン（該当する場合）: n/a

## 影響分析
### 影響を受けるコンポーネント
- [ ] CLIコマンド（`cmd/`）
- [ ] ベクトル化（`internal/vectorizer/`）
- [ ] OpenSearch統合（`internal/opensearch/`）
- [ ] S3 Vector操作（`internal/s3vector/`）
- [x] Slack bot（`internal/slackbot/`）
- [ ] Bedrock埋め込み（`internal/embedding/`）
- [ ] 設定（`internal/config/`）

### AWSリソースへの影響
- [x] AWSリソースの変更なし

## 破壊的変更
- [x] なし

挙動の補足: 検索クエリへ供給するスレッド履歴から Bot 発話を除外するように変更。Slack 上で見えるスレッド本文は変更しない。

## 依存関係
- [x] 新しい依存関係なし

## ドキュメント
- [ ] README.md更新
- [ ] CLAUDE.md更新
- [x] インラインコードコメントの追加/更新
- [ ] APIドキュメント更新
- [ ] 設定例の更新

## チェックリスト
- [x] コードがプロジェクトのスタイルガイドラインに従っている（`go fmt ./...` と `go vet ./...`）
- [x] 自分のコードをセルフレビューした
- [x] 理解が困難な領域にコメントを追加した
- [ ] ドキュメントに対応する変更を行った
- [x] 変更によって新しい警告やエラーが生成されない
- [x] 修正が効果的であることまたは機能が動作することを証明するテストを追加した
- [x] 新しいテストと既存のユニットテストがローカルで成功する
- [x] 依存する変更がマージされ公開されている
- [x] セキュリティ問題や露出した秘密情報がないかコードをチェックした
- [x] サポートされる最小Goバージョン（1.23）でテストした
- [ ] `go mod tidy`を実行して依存関係をクリーンアップした

## パフォーマンスに関する考慮事項
- [x] パフォーマンスへの影響なし

dedup マップは最大 4096 件・TTL 5 分で機会的 GC を行うため、メモリは O(maxSize)。ルックアップは単一 mutex 下で O(1)。

## 追加ノート
dedup キーは意図的に重ね掛けしている（Events API は `event_id`、RTM は `client_msg_id`、いずれもフォールバックは `channel:ts`）。いずれかのトランスポート都合でキーが欠落しても他層で必ず検出できる。

## スクリーンショット/ログ
n/a
