### PR TITLE
feat(slacksearch): support assistant search action tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,20 @@ EXCLUDE_CATEGORIES=個人メモ,日報
 
 # Slack Bot Configuration
 SLACK_BOT_TOKEN=xoxb-your-bot-token
-SLACK_USER_TOKEN=xoxp-your-user-token-with-search-scope
+# SLACK_USER_TOKEN is optional but recommended.
+#
+# - When set (xoxp): all Slack search paths (slack-bot / query CLI / mcp-server)
+#   use the legacy `search.messages` API with the `search:read` user scope.
+#   This covers public channels, private channels (the user is a member of),
+#   DMs and MPIMs.
+# - When unset: only the slack-bot mention path can search Slack. It uses
+#   the Real-time Search API (`assistant.search.context`) on the bot token
+#   plus the short-lived `action_token` surfaced by `app_mention` / DM
+#   `message` events. This requires the bot to have `search:read.public` and
+#   reaches public channels even ones the bot has not joined. The `query`
+#   CLI and `mcp-server` cannot supply an `action_token`, so they skip Slack
+#   search entirely when SLACK_USER_TOKEN is not set.
+SLACK_USER_TOKEN=
 SLACK_APP_TOKEN=xapp-your-app-token
 
 # Slack Search Configuration

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
         run: make fmtvet
 
       - name: Run golangci-lint (Action)
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.10.1
           args: --timeout=5m

--- a/README.md
+++ b/README.md
@@ -813,7 +813,16 @@ OIDC_CLIENT_SECRET=your_client_secret
 
 # Slack Bot Configuration
 SLACK_BOT_TOKEN=xoxb-your-bot-token
-SLACK_USER_TOKEN=xoxp-your-user-token-with-search-read
+# SLACK_USER_TOKEN is optional but covers more paths.
+# - When set (xoxp): all entry points (slack-bot / query CLI / mcp-server)
+#   use the legacy `search.messages` API and can reach private channels,
+#   DMs and MPIMs that the user has access to.
+# - When unset: only the slack-bot mention path can search Slack. It calls
+#   the Real-time Search API (`assistant.search.context`) on the bot token
+#   plus the per-event `action_token` and reaches public channels the bot
+#   has not joined (requires the `search:read.public` bot scope). CLI/MCP
+#   cannot obtain an `action_token` and therefore skip Slack search.
+SLACK_USER_TOKEN=
 SLACK_RESPONSE_TIMEOUT=5s
 SLACK_MAX_RESULTS=5
 SLACK_ENABLE_THREADING=false
@@ -880,7 +889,12 @@ When `EMBEDDING_MODEL` is omitted, Gemini defaults to `text-embedding-004` (768 
 
 Models such as `gemini-embedding-2-preview` support configurable output dimensions. Set `EMBEDDING_DIMENSION` to match your vector store index — for example `EMBEDDING_DIMENSION=1024` for an OpenSearch index created with 1024 dimensions. When omitted, the model's default dimension is used.
 
-Slack search requires `SLACK_SEARCH_ENABLED=true`, a valid `SLACK_BOT_TOKEN`, **and** a user token `SLACK_USER_TOKEN` that includes scopes such as `search:read`, `channels:history`, `groups:history`, and other conversation history scopes relevant to the channels you query. The search-specific knobs let you tune throughput and cost per workspace without touching the core document pipeline.
+Slack search requires `SLACK_SEARCH_ENABLED=true` and a valid `SLACK_BOT_TOKEN`. `SLACK_USER_TOKEN` (`xoxp-`) is **optional** but determines which entry points can search Slack:
+
+- **With `SLACK_USER_TOKEN`** — every entry point (`slack-bot`, `query` CLI, `mcp-server`) calls the legacy `search.messages` API with the user-token `search:read` scope. Results cover public channels, private channels the user belongs to, plus DMs / MPIMs.
+- **Without `SLACK_USER_TOKEN`** — only the `slack-bot` mention path can search Slack. It switches to the Real-time Search API (`assistant.search.context`) using the bot token together with the short-lived `action_token` carried by `app_mention` / DM `message` events. The bot needs the granular `search:read.public` scope and reaches public channels even ones the bot has not been invited to. The `query` CLI and `mcp-server` cannot obtain an `action_token`, so they refuse to run Slack search in this mode (other RAGent features continue to work).
+
+The search-specific knobs let you tune throughput and cost per workspace without touching the core document pipeline. See [`docs/slack-user-token.md`](docs/slack-user-token.md) for the full rationale of when a user token is required.
 
 ### MCP Bypass Configuration (Optional)
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -789,7 +789,17 @@ EXCLUDE_CATEGORIES=個人メモ,日報  # 検索から除外するカテゴリ
 
 # Slack Bot設定
 SLACK_BOT_TOKEN=xoxb-your-bot-token
-SLACK_USER_TOKEN=xoxp-your-user-token-with-search-read
+# SLACK_USER_TOKEN は任意。設定状況によって利用できる経路が変わります。
+# - 設定する場合 (xoxp): slack-bot / query CLI / mcp-server すべての経路で
+#   `search.messages` API を使用 (user scope `search:read`)。
+#   public / private / DM / MPIM を user の権限範囲で横断検索できる。
+# - 未設定の場合: slack-bot のメンション応答経路のみ Slack 検索が動作する。
+#   Real-time Search API (`assistant.search.context`) を Bot Token と
+#   `app_mention` / DM `message` イベント由来の `action_token` で呼び出し、
+#   Bot 未参加の public channel まで検索可能 (`search:read.public` 要)。
+#   query CLI / mcp-server は action_token を取得できないため Slack 検索を
+#   skip する。
+SLACK_USER_TOKEN=
 SLACK_RESPONSE_TIMEOUT=5s
 SLACK_MAX_RESULTS=5
 SLACK_ENABLE_THREADING=false
@@ -862,7 +872,12 @@ export GEMINI_GCP_LOCATION=us-central1
 
 `gemini-embedding-2-preview` などのモデルは出力次元数を変更できます。`EMBEDDING_DIMENSION` でベクトルストアのインデックスに合わせてください。例えば、1024次元で作成された OpenSearch インデックスには `EMBEDDING_DIMENSION=1024` を指定します。省略時はモデルのデフォルト次元数が使用されます。
 
-Slack検索を利用する場合は、`SLACK_SEARCH_ENABLED=true`・`SLACK_BOT_TOKEN` に加えて、`search:read` や `channels:history` / `groups:history` など必要なスコープを付与した `SLACK_USER_TOKEN` を同じワークスペースで設定してください。Slack検索用の環境変数でスループットや動作を調整できます。
+Slack検索を利用する場合は、`SLACK_SEARCH_ENABLED=true` と `SLACK_BOT_TOKEN` を必ず設定してください。`SLACK_USER_TOKEN`（`xoxp-`）の有無で使える経路が変わります。
+
+- **`SLACK_USER_TOKEN` を設定する場合** — `slack-bot` / `query` CLI / `mcp-server` すべての経路で従来の `search.messages` API (`search:read` user scope) を使用。public / private / DM / MPIM をユーザー権限の範囲で横断検索できる。
+- **`SLACK_USER_TOKEN` を設定しない場合** — `slack-bot` のメンション応答経路のみ Slack 検索が動作。Real-time Search API (`assistant.search.context`) を Bot Token と `app_mention` / DM `message` イベントに同梱される短命の `action_token` で呼び出し、`search:read.public` スコープがあれば Bot 未参加の public channel まで検索できる。`query` CLI と `mcp-server` は `action_token` を取得する手段がないため Slack 検索を skip する (他の RAGent 機能は引き続き動作)。
+
+Slack検索用の環境変数でスループットや動作を調整できます。User Token がなぜ必要かの詳細は [`docs/slack-user-token.md`](docs/slack-user-token.md) を参照してください。
 
 ### MCPバイパス設定（任意）
 

--- a/cmd/slack_test.go
+++ b/cmd/slack_test.go
@@ -170,10 +170,17 @@ type stubSlackService struct {
 	result       *slacksearch.SlackSearchResult
 	lastQuery    string
 	lastChannels []string
+	lastOpts     slacksearch.SearchOptions
 }
 
-func (s *stubSlackService) Search(ctx context.Context, query string, channels []string) (*slacksearch.SlackSearchResult, error) {
+func (s *stubSlackService) Search(
+	ctx context.Context,
+	query string,
+	channels []string,
+	opts slacksearch.SearchOptions,
+) (*slacksearch.SlackSearchResult, error) {
 	s.lastQuery = query
 	s.lastChannels = channels
+	s.lastOpts = opts
 	return s.result, nil
 }

--- a/docs/slack-user-token.md
+++ b/docs/slack-user-token.md
@@ -1,0 +1,260 @@
+# RAGent における Slack User Token 必要性の根拠
+
+> **対象読者**: Slack ワークスペース管理者
+> **目的**: RAGent の Slack 検索機能に対して User Token (`xoxp-`) の発行・スコープ付与の判断材料を提供する
+
+---
+
+## TL;DR
+
+- RAGent は Slack 検索バックエンドを 2 つ持つ:
+  - **`search.messages` (User Token / `xoxp-`)** — 従来からの全文検索 API。private channel / DM / MPIM もユーザーの権限範囲で検索可能。
+  - **`assistant.search.context` (Bot Token / `xoxb-` + `action_token`)** — Slack の Real-time Search API。Bot 未参加 public channel まで検索可能だが、Slack イベント (`app_mention` / DM `message`) から取得する短命の `action_token` が無いと呼べない。
+- **slack-bot のメンション応答** は Bot Token + `action_token` で `assistant.search.context` を使えるため、User Token 不要でも動作する (ただし public channel 限定)。
+- **`query` CLI / `mcp-server`** は Slack イベント駆動ではないため `action_token` を取得できず、結果として `search.messages` (User Token) しか選べない。**User Token が無いとこれらの経路では Slack 検索が無効化される**。
+- 全経路で Slack 検索を有効化したい場合、および public 以外 (private / DM / MPIM) も検索対象に含めたい場合は **`search:read` を持つ User Token が必須**。
+
+---
+
+## 1. 背景: RAGent が Slack 検索で行うこと
+
+RAGent は社内ナレッジ検索を行う RAG (Retrieval-Augmented Generation) システムで、以下の経路で Slack 検索を使う。経路ごとに使える API と権限が異なる。
+
+| 利用シーン | User Token 設定時 | User Token 未設定時 |
+|---|---|---|
+| `slack-bot` (Bot へのメンション応答) | `search.messages` (public + private + DM + MPIM) | `assistant.search.context` (public のみ。Bot 未参加 ch も検索可) |
+| `query` (CLI) | `search.messages` (public + private + DM + MPIM) | **Slack 検索 skip** (action_token を取れないため) |
+| `mcp-server` (外部 AI クライアントへの MCP ツール提供) | `search.messages` (public + private + DM + MPIM) | **Slack 検索 skip** (同上) |
+
+つまり、User Token がなくても slack-bot のメンション応答経路だけは部分的に動作するが、`query` / `mcp-server` で Slack 検索を使いたい場合や、private channel / DM / MPIM を検索対象に含めたい場合は User Token が必須となる。
+
+---
+
+## 2. 技術的根拠: Slack API の制約
+
+### 2.1 `search.messages` は User Token 専用
+
+Slack 公式 docs ([search.messages](https://docs.slack.dev/reference/methods/search.messages)) に明記:
+
+| 項目 | 値 |
+|---|---|
+| Required scope | **User token scope: `search:read`** |
+| Bot token support | **なし** |
+| ステータス | **Legacy method** (新規開発は `assistant.search.context` 推奨) |
+
+`search.all`, `search.files` も同様に User Token 専用。
+
+### 2.2 Bot 用 `search:read.public` は別 API のためのスコープ
+
+Slack には `search:read.public` / `search:read.private` / `search:read.im` / `search:read.mpim` / `search:read.users` / `search:read.files` という granular scope 群があるが、これらは **Real-time Search API (`assistant.search.context`)** のためのスコープであり、`search.messages` では使えない。
+
+→ 公式 docs: <https://docs.slack.dev/reference/scopes/search.read.public>
+
+### 2.3 実機検証結果
+
+ワークスペース `ca-winticket.slack.com` で発行された Bot Token (xoxb) に `search:read.public` 等のスコープを付与した状態で `search.messages` を呼んだところ、以下のレスポンス:
+
+```json
+{ "ok": false, "error": "not_allowed_token_type" }
+```
+
+Slack 側が **token type そのもので拒否** しており、スコープを追加しても解消しない (公式仕様と一致)。
+
+---
+
+## 3. 代替手段が成立しない理由
+
+### 3.1 `assistant.search.context` (Real-time Search API) — slack-bot だけ部分的に成立
+
+公式 docs: <https://docs.slack.dev/reference/methods/assistant.search.context>
+
+- Bot Token でも呼び出し可能だが、**呼び出し時に `action_token` (Slack イベントに同梱される短命トークン) が必須**
+- `action_token` は `app_mention` / `message.im` などの **Slack イベント受信時のみ取得可能** (`event.assistant_thread.action_token`)
+- 検索範囲は **public channel のみ**。`search:read.private` / `search:read.im` / `search:read.mpim` は **User Token only** スコープなので、Bot Token 経由では private/DM/MPIM を検索できない
+- 検索は `on behalf of the authenticated user` で実行されるので、メンションしたユーザーがアクセスできない情報は返らない (情報漏えい防止)
+- **RAGent では slack-bot のメンション応答経路だけが action_token を取れる**ため、この経路に限り User Token なしでも検索可能 (public ch 限定)
+- `query` / `mcp-server` は Slack イベント駆動ではないため `action_token` を取得する手段がなく、この API を使えない
+
+→ **slack-bot のメンション応答時のみ部分的に代替可能**だが、`query` / `mcp-server` の検索経路は救えない。また private / DM / MPIM はどの経路でも User Token なしでは検索できない。
+
+### 3.2 `conversations.history` でクライアントサイド全文検索
+
+- Bot Token + `channels:history` 等で取得可能だが、**全文検索ではない** (チャネル単位での履歴取得)
+- 検索ワードでのフィルタリングはクライアントサイド実装が必要
+- チャネルを事前に列挙する必要があり、ワークスペース全体を横断できない
+- メッセージ件数次第で API レート制限・遅延が深刻 (数万件以上のチャネルでは現実的でない)
+- スレッド・添付ファイル・メンション展開の取り扱いを自前実装する必要がある
+
+→ RAGent のように「自然文クエリで関連会話を横断検索」するユースケースには**機能的にも性能的にも不適**。
+
+### 3.3 Enterprise Grid 限定 API
+
+`admin.conversations.search` 等は Enterprise Grid 限定かつ管理者用途で、一般のメッセージ全文検索ではない。
+
+---
+
+## 4. 申請してほしい User Token と最小スコープ
+
+### 4.1 User Token (`xoxp-`)
+
+検索したい範囲に応じて以下を付与:
+
+| スコープ | 必須度 | 用途 |
+|---|---|---|
+| `search:read` | **必須** | `search.messages` 本体 |
+| `channels:history` | 強く推奨 | 検索でヒットした public channel のメッセージ・スレッド本文を取得 |
+| `groups:history` | 推奨 | 検索でヒットした private channel のメッセージ・スレッド本文を取得 |
+| `im:history` | 任意 | DM を検索対象に含める場合 |
+| `mpim:history` | 任意 | group DM を検索対象に含める場合 |
+| `users:read` | 推奨 | メッセージ送信者の表示名を取得 |
+| `channels:read` / `groups:read` | 推奨 | チャネル名解決 |
+
+### 4.2 Bot Token (`xoxb-`) (既存)
+
+RAGent の応答送信や URL 直接取得で別途必要 (本資料の主題ではないので割愛)。
+
+---
+
+## 5. セキュリティ上の留意点
+
+| 項目 | 対応 |
+|---|---|
+| トークン発行ユーザー | **専用のシステムユーザー (例: `rag-bot`) で発行する**。個人ユーザーのトークンは退職等で失効するため避ける |
+| 保管場所 | **AWS Secrets Manager** に格納し、RAGent は `SECRET_MANAGER_SECRET_ID` 経由で起動時に注入する (.env 直書き禁止) |
+| ローテーション | Slack OAuth で Token Rotation を有効化、もしくは定期手動ローテーションを運用に組み込む |
+| アクセス可能範囲 | User Token の権限は発行ユーザーが参加しているチャネルに準ずる。検索対象を絞りたい場合は発行ユーザーの所属チャネルで制御する |
+| 監査 | Slack の Audit Logs (Enterprise Grid) で API 呼び出しを監視可能 |
+
+---
+
+## 6. `SLACK_USER_TOKEN` 不要で slack-bot を動かす場合の Slack App 設定
+
+User Token を発行せず、slack-bot 経路だけ `assistant.search.context` (Real-time Search API) で動かす場合、Slack App を **AI-enabled app (Agents & AI Apps)** として構成する必要があります。これを満たさないと、`app_mention` イベント payload に `action_token` が一切含まれません (RAGent のログでは `action_token_probe top_level=false assistant_thread=false` として観測されます)。
+
+公式の根拠:
+
+> The `app_mention` event contains an `action_token` in the payload when the app is mentioned using `@app-name`.
+> — https://docs.slack.dev/apis/web-api/real-time-search-api/#action-token
+
+ただし RTS 自体は AI-enabled app 向けです。通常の bot のままでは token は出ません。
+
+### 6.1 必要な Slack App 設定
+
+1. **App Settings を開く**: <https://api.slack.com/apps>{your_app_id}
+2. **「Agents & AI Apps」を有効化** (左サイドバー → Agents & AI Apps → Enable)
+   - これで `assistant:write` scope が自動的に bot に追加されます (公式: <https://docs.slack.dev/ai/developing-agents#enabling-the-assistant-feature>)
+3. **Manifest に `features.assistant_view` を追加** (UI 設定で「Agents & AI Apps」を有効化すると裏側で同等のものが入りますが、manifest 管理しているなら明示):
+   ```yaml
+   features:
+     assistant_view:
+       assistant_description: "RAGent answers questions using Slack context."
+       suggested_prompts: []
+   ```
+4. **Bot scopes に以下を含める** (どれも既存運用と非破壊):
+   - `app_mentions:read` (既存)
+   - `chat:write` (既存)
+   - `assistant:write` (Agents & AI Apps を ON にすれば自動付与)
+   - `search:read.public` (Real-time Search API 用)
+   - `im:history` (DM 経由のメンションを扱うなら)
+5. **Event Subscriptions に以下を含める**:
+   - `app_mention` (既存)
+   - `message.im` (DM 検索を許すなら)
+   - `assistant_thread_started`
+   - `assistant_thread_context_changed`
+   - 公式: <https://docs.slack.dev/ai/developing-agents#enabling-the-assistant-feature>
+6. **Workspace に Reinstall** (Manage Distribution → Reinstall)
+   - **必須**。Scope や Manifest を変更しても再インストールしない限り発行済みトークンには反映されません。
+
+### 6.2 App 種別の制約
+
+公式 docs:
+
+> The RTS API is available for directory-published apps and internal apps only.
+> — https://docs.slack.dev/apis/web-api/real-time-search-api/#overview
+
+- **Internal app** (Workspace 専用 / 単一 Workspace install): ✅ 利用可
+- **Slack Marketplace (directory-published)**: ✅ 利用可
+- **Unlisted distributed app** (公開せず distributed としているもの): ❌ 利用不可
+
+社内利用なら "Internal app" として作っておけば OK です。
+
+### 6.3 Guests は対象外
+
+> Workspace guests are not permitted to access apps using platform AI features...
+> — https://docs.slack.dev/apis/web-api/real-time-search-api/#guests
+
+ゲストユーザーが `@bot` を呼んでも token は発行されません。
+
+### 6.4 設定後の確認方法
+
+RAGent は受信した event の raw payload を probe して以下のログを出します:
+
+```
+event=events_api action_token_probe top_level=<bool> assistant_thread=<bool>
+```
+
+| パターン | 状況 | 次のアクション |
+|---|---|---|
+| `top_level=false assistant_thread=false` | Slack が token を発行していない | Agents & AI Apps 有効化 / Reinstall を確認 |
+| `top_level=true` または `assistant_thread=true` | token は受け取れている | `assistant.search.context` が呼ばれるはず |
+
+`has_action_token=true` がログに出れば、`assistant.search.context` への切り替えは自動で行われます。
+
+---
+
+## 7. User Token を発行できない場合の影響
+
+User Token を付与できない場合、RAGent は以下の動作になる:
+
+- `slack-bot` のメンション応答経路 — `assistant.search.context` (Bot Token + `action_token`) で **public channel の検索のみ動作**。Bot 未参加の public channel も検索ヒット可能。**private channel / DM / MPIM は検索不可**
+- `query` CLI / `mcp-server` — Slack 検索は **無効化**される (`action_token` を取得できないため `assistant.search.context` を呼べず、User Token もないため `search.messages` も呼べない)。明示的にエラーメッセージを返すか、警告ログを出して Slack 検索をスキップして RAGent 本体は動作する
+- OpenSearch を使った社内ドキュメント検索 (Markdown / GitHub 等) は **引き続き利用可能**
+- `slack-bot` 自体はメンション応答や URL 引用などの基本機能は動作する (Bot Token のみで OK)
+
+検索品質と網羅性を考えると User Token を発行することが推奨されるが、最小構成で運用したい場合は **slack-bot 経路 + public ch 検索のみ** で運用することも可能。
+
+---
+
+## 8. 参考リンク (Slack 公式)
+
+- [`search.messages` — Legacy User Token 専用](https://docs.slack.dev/reference/methods/search.messages)
+- [`search:read` (legacy user scope)](https://docs.slack.dev/reference/scopes/search.read)
+- [`search:read.public` (Bot 用 granular scope。`assistant.search.context` 用)](https://docs.slack.dev/reference/scopes/search.read.public)
+- [`assistant.search.context` (Real-time Search API)](https://docs.slack.dev/reference/methods/assistant.search.context)
+- [Real-time Search API ガイド](https://docs.slack.dev/apis/web-api/real-time-search-api)
+- [Changelog: Slack MCP server / Real-time Search API (2026-02-17)](https://docs.slack.dev/changelog/2026/02/17/slack-mcp)
+- [Agents & AI Apps を有効化する手順](https://docs.slack.dev/ai/developing-agents#enabling-the-assistant-feature)
+- [`assistant_thread_started` event](https://docs.slack.dev/reference/events/assistant_thread_started)
+- [App Manifest reference](https://docs.slack.dev/reference/app-manifest/)
+
+---
+
+## 付録: 検証コマンド (再現用)
+
+```bash
+# 1. Bot Token の有効性とスコープを確認
+curl -s -X POST "https://slack.com/api/auth.test" \
+  -H "Authorization: Bearer xoxb-***" \
+  -D headers.txt | jq .
+grep -i "x-oauth-scopes" headers.txt
+
+# 2. search.messages を Bot Token で叩く (失敗する)
+curl -s -X POST "https://slack.com/api/search.messages" \
+  -H "Authorization: Bearer xoxb-***" \
+  --data-urlencode "query=hello" | jq .
+# => {"ok": false, "error": "not_allowed_token_type"}
+
+# 3. search.messages を User Token で叩く (成功する)
+curl -s -X POST "https://slack.com/api/search.messages" \
+  -H "Authorization: Bearer xoxp-***" \
+  --data-urlencode "query=hello" | jq .
+# => {"ok": true, "messages": {...}}
+
+# 4. assistant.search.context は action_token が必要 (action_token 単独では
+#    手動再現できないので、Bot の app_mention イベント payload から取り出した
+#    値を使う)。RAGent では slack-bot 経路で自動的に処理される。
+curl -s -X POST "https://slack.com/api/assistant.search.context" \
+  -H "Authorization: Bearer xoxb-***" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data '{"query":"hello","action_token":"<from app_mention event>"}' | jq .
+```

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/netflix/go-env v0.0.0-20220526054621-78278af1949d
 	github.com/opensearch-project/opensearch-go/v4 v4.5.0
 	github.com/pdfcpu/pdfcpu v0.11.1
-	github.com/slack-go/slack v0.17.3
+	github.com/slack-go/slack v0.23.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -193,6 +193,8 @@ github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnB
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/slack-go/slack v0.17.3 h1:zV5qO3Q+WJAQ/XwbGfNFrRMaJ5T/naqaonyPV/1TP4g=
 github.com/slack-go/slack v0.17.3/go.mod h1:X+UqOufi3LYQHDnMG1vxf0J8asC6+WllXrVrhl8/Prk=
+github.com/slack-go/slack v0.23.1 h1:ZS5B96wxxYQRwvJ3/vJFtqtUZi3tXhsZCyT44Nv7M80=
+github.com/slack-go/slack v0.23.1/go.mod h1:H0yR/YBuRJ39RkE+JpV/d/oEsbanzTRowR82bCN0cEs=
 github.com/spf13/afero v1.2.1 h1:qgMbHoJbPbw579P+1zVY+6n4nIFuIchaIjzZ/I/Yq8M=
 github.com/spf13/afero v1.2.1/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=

--- a/internal/mcpserver/command.go
+++ b/internal/mcpserver/command.go
@@ -340,10 +340,18 @@ func RunMCPServer(ctx context.Context, cmd FlagChecker, opts MCPServerOptions) e
 			}
 			logger.Printf("Slack search disabled: SLACK_BOT_TOKEN is not configured")
 		} else if strings.TrimSpace(cfg.SlackUserToken) == "" {
+			// MCP server has no Slack event surface, so it cannot obtain an
+			// action_token for assistant.search.context. Without a user token
+			// there is no viable Slack search backend; skip initialization
+			// instead of failing to be tolerant for setups that intentionally
+			// run RAGent without Slack search.
 			if opts.OnlySlack {
-				return fmt.Errorf("SLACK_USER_TOKEN is required in --only-slack mode")
+				return fmt.Errorf(
+					"SLACK_USER_TOKEN is required in --only-slack mode " +
+						"(assistant.search.context needs a Slack event action_token, which the MCP server cannot provide)")
 			}
-			logger.Printf("Slack search disabled: SLACK_USER_TOKEN is not configured")
+			logger.Printf("Slack search disabled: SLACK_USER_TOKEN is not configured; " +
+				"the MCP server cannot supply an action_token for assistant.search.context")
 		} else {
 			slackClient := slack.New(slackCfg.BotToken)
 			service, serr := slacksearch.NewSlackSearchService(cfg, slackClient, slackBedrockClient, logger)

--- a/internal/mcpserver/hybrid_search_tool.go
+++ b/internal/mcpserver/hybrid_search_tool.go
@@ -283,7 +283,9 @@ func (hsta *HybridSearchToolAdapter) HandleToolCallWithProgress(ctx context.Cont
 			timeout = 10
 		}
 		slackCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
-		slackResult, err = hsta.slackService.Search(slackCtx, searchRequest.Query, searchRequest.SlackChannels)
+		// MCP callers do not supply a Slack event action_token, so slacksearch
+		// uses the legacy user-token (search.messages) backend.
+		slackResult, err = hsta.slackService.Search(slackCtx, searchRequest.Query, searchRequest.SlackChannels, slacksearch.SearchOptions{})
 		cancel()
 
 		// Clear progress handler after search

--- a/internal/mcpserver/slack_search_tool.go
+++ b/internal/mcpserver/slack_search_tool.go
@@ -137,7 +137,9 @@ func (sta *SlackSearchToolAdapter) HandleToolCallWithProgress(ctx context.Contex
 	defer cancel()
 
 	startTime := time.Now()
-	result, err := sta.slackService.Search(searchCtx, request.Query, request.Channels)
+	// MCP callers do not supply a Slack event action_token, so slacksearch
+	// uses the legacy user-token (search.messages) backend.
+	result, err := sta.slackService.Search(searchCtx, request.Query, request.Channels, slacksearch.SearchOptions{})
 
 	// Clear progress handler
 	if progressFn != nil {

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -136,9 +136,10 @@ func validateSlackSearchConfig(config *Config) error {
 		return nil
 	}
 
-	if strings.TrimSpace(config.SlackUserToken) == "" {
-		return fmt.Errorf("SLACK_USER_TOKEN is required when Slack search is enabled")
-	}
+	// SLACK_USER_TOKEN is optional. When unset, only callers that can provide
+	// a Slack event action_token (slack-bot mentions/DMs) can use the
+	// assistant.search.context backend; CLI/MCP Slack search still requires a
+	// user token because they have no Slack event surface.
 
 	if config.SlackSearchMaxResults <= 0 || config.SlackSearchMaxResults > 100 {
 		return fmt.Errorf("SLACK_SEARCH_MAX_RESULTS must be between 1 and 100 (got %d)", config.SlackSearchMaxResults)

--- a/internal/pkg/slacksearch/assistant_searcher.go
+++ b/internal/pkg/slacksearch/assistant_searcher.go
@@ -301,7 +301,7 @@ func (s *AssistantSearcher) recordFailure() {
 }
 
 func convertAssistantSearchMessage(m slack.AssistantSearchContextMessage) slack.Message {
-	return slack.Message{
+	msg := slack.Message{
 		Msg: slack.Msg{
 			Channel:   m.ChannelID,
 			User:      m.AuthorUserID,
@@ -312,6 +312,10 @@ func convertAssistantSearchMessage(m slack.AssistantSearchContextMessage) slack.
 			Blocks:    m.Blocks,
 		},
 	}
+	if m.IsAuthorBot {
+		msg.SubType = "bot_message"
+	}
+	return msg
 }
 
 func convertAssistantSearchEnrichedMessage(m slack.AssistantSearchContextMessage) EnrichedMessage {
@@ -333,6 +337,9 @@ func convertAssistantSearchContextMessages(messages []slack.AssistantSearchConte
 	}
 	converted := make([]slack.Message, 0, len(messages))
 	for _, msg := range messages {
+		if msg.IsAuthorBot {
+			continue
+		}
 		converted = append(converted, convertAssistantSearchMessage(msg))
 	}
 	return converted

--- a/internal/pkg/slacksearch/assistant_searcher.go
+++ b/internal/pkg/slacksearch/assistant_searcher.go
@@ -1,0 +1,332 @@
+package slacksearch
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/slack-go/slack"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// assistantSearchClient narrows the slack.Client surface that
+// AssistantSearcher depends on so it can be replaced in unit tests.
+type assistantSearchClient interface {
+	SearchAssistantContextContext(
+		ctx context.Context,
+		params slack.AssistantSearchContextParameters,
+	) (*slack.AssistantSearchContextResponse, error)
+}
+
+// AssistantSearcher invokes Slack's `assistant.search.context` API on a Bot
+// Token. The caller must surface a short-lived `action_token` obtained from
+// an `app_mention` or `message` event (Real-time Search API). The bot can
+// then search public channels it has not been invited to, as long as the
+// `search:read.public` granular scope is granted.
+type AssistantSearcher struct {
+	client         assistantSearchClient
+	rateLimiter    *RateLimiter
+	logger         *log.Logger
+	requestTimeout time.Duration
+
+	mu               sync.Mutex
+	consecutiveError int
+	circuitOpenUntil time.Time
+}
+
+// NewAssistantSearcher constructs an AssistantSearcher backed by the given
+// Slack client (typically the Bot Token client).
+func NewAssistantSearcher(client *slack.Client, rateLimiter *RateLimiter, requestTimeout time.Duration) *AssistantSearcher {
+	logger := log.New(log.Default().Writer(), "slacksearch/assistant ", log.LstdFlags)
+	return &AssistantSearcher{
+		client:         client,
+		rateLimiter:    rateLimiter,
+		logger:         logger,
+		requestTimeout: requestTimeout,
+	}
+}
+
+// Search performs a single assistant.search.context call. The request must
+// include a non-empty ActionToken.
+func (s *AssistantSearcher) Search(ctx context.Context, req *SearchRequest) (*SearchResponse, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, span := slackSearchTracer.Start(ctx, "slacksearch.assistant.search")
+	defer span.End()
+
+	if req == nil {
+		err := fmt.Errorf("search request cannot be nil")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "invalid_request")
+		return nil, err
+	}
+	if s.client == nil {
+		err := fmt.Errorf("slack client not configured")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "client_not_configured")
+		return nil, err
+	}
+
+	query := strings.TrimSpace(req.Query)
+	if query == "" {
+		err := fmt.Errorf("search query cannot be empty")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "invalid_query")
+		return nil, err
+	}
+	if strings.TrimSpace(req.ActionToken) == "" {
+		err := fmt.Errorf("action_token is required for assistant.search.context")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "missing_action_token")
+		return nil, err
+	}
+
+	queryHash := telemetryFingerprint(query)
+	span.SetAttributes(
+		attribute.String("slack.query_hash", queryHash),
+		attribute.Int("slack.max_results_requested", req.MaxResults),
+		attribute.Bool("slack.has_context_channel_id", strings.TrimSpace(req.ContextChannelID) != ""),
+	)
+
+	if err := s.ensureCircuitAvailable(); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "circuit_open")
+		return nil, err
+	}
+
+	if s.rateLimiter != nil && !s.rateLimiter.Allow(slackSearchRateLimitKey, slackSearchRateLimitKey) {
+		err := fmt.Errorf("slack search rate limit exceeded")
+		s.logger.Printf("Slack assistant search rate limit triggered hash=%s", queryHash)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "rate_limited")
+		return nil, err
+	}
+
+	params := slack.AssistantSearchContextParameters{
+		Query:                  query,
+		ActionToken:            req.ActionToken,
+		ChannelTypes:           []string{"public_channel"},
+		ContentTypes:           []string{"messages"},
+		Limit:                  clamp(max(req.MaxResults, defaultSearchResultLimit), minSearchResults, maxSearchResults),
+		IncludeContextMessages: true,
+		Sort:                   "timestamp",
+		SortDir:                "desc",
+	}
+	if strings.TrimSpace(req.ContextChannelID) != "" {
+		params.ContextChannelID = req.ContextChannelID
+	}
+	if req.TimeRange != nil {
+		if req.TimeRange.Start != nil {
+			params.After = req.TimeRange.Start.Unix()
+		}
+		if req.TimeRange.End != nil {
+			params.Before = req.TimeRange.End.Unix()
+		}
+	}
+
+	span.SetAttributes(
+		attribute.Int("slack.request_limit", params.Limit),
+		attribute.Bool("slack.time_filter_present", req.TimeRange != nil),
+	)
+
+	ctx, cancel := context.WithTimeout(ctx, s.requestTimeout)
+	defer cancel()
+
+	s.logger.Printf("Slack assistant search executing hash=%s limit=%d", queryHash, params.Limit)
+	resp, err := s.client.SearchAssistantContextContext(ctx, params)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "search_failed")
+		return nil, err
+	}
+	if resp == nil {
+		err := fmt.Errorf("assistant.search.context returned nil response")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "search_failed")
+		return nil, err
+	}
+	if !resp.Ok {
+		slackErr := strings.TrimSpace(resp.Error)
+		if slackErr == "" {
+			slackErr = "unknown_error"
+		}
+		err := fmt.Errorf("assistant.search.context: %s", slackErr)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "search_not_ok")
+		return nil, err
+	}
+
+	messages := make([]slack.Message, 0, len(resp.Results.Messages))
+	for _, match := range resp.Results.Messages {
+		messages = append(messages, convertAssistantSearchMessage(match))
+	}
+
+	hasMore := strings.TrimSpace(resp.ResponseMetadata.NextCursor) != ""
+	response := &SearchResponse{
+		Messages:   messages,
+		TotalCount: len(messages),
+		HasMore:    hasMore,
+		Query:      query,
+	}
+
+	span.SetAttributes(
+		attribute.Int("slack.messages_returned", len(messages)),
+		attribute.Int("slack.total_count", len(messages)),
+		attribute.Bool("slack.has_more", hasMore),
+	)
+	s.logger.Printf("Slack assistant search completed hash=%s returned=%d has_more=%t", queryHash, len(messages), hasMore)
+
+	return response, nil
+}
+
+// SearchWithRetry mirrors Searcher.SearchWithRetry for the assistant path
+// with retry, circuit breaking, and fatal-error fast-fail handling.
+func (s *AssistantSearcher) SearchWithRetry(ctx context.Context, req *SearchRequest, maxRetries int) (*SearchResponse, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, span := slackSearchTracer.Start(ctx, "slacksearch.assistant.search_with_retry")
+	defer span.End()
+
+	queryHash := telemetryFingerprint(req.Query)
+	span.SetAttributes(
+		attribute.String("slack.query_hash", queryHash),
+		attribute.Int("slack.max_retries", maxRetries),
+	)
+
+	if err := s.ensureCircuitAvailable(); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "circuit_open")
+		return nil, err
+	}
+
+	attempts := maxRetries + 1
+	var lastErr error
+
+	for attempt := 0; attempt < attempts; attempt++ {
+		span.AddEvent("search_attempt", trace.WithAttributes(attribute.Int("slack.attempt_index", attempt+1)))
+		resp, err := s.Search(ctx, req)
+		if err == nil {
+			s.recordSuccess()
+			span.SetAttributes(attribute.Int("slack.attempts_used", attempt+1))
+			return resp, nil
+		}
+
+		lastErr = err
+		s.recordFailure()
+
+		if isAssistantFatalError(err) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "non_retryable_error")
+			return nil, lastErr
+		}
+
+		retryAfter, retryable := classifySlackError(err)
+		if !retryable || attempt == maxRetries {
+			span.RecordError(err)
+			if retryable {
+				span.SetStatus(codes.Error, "max_retries_exhausted")
+			} else {
+				span.SetStatus(codes.Error, "non_retryable_error")
+			}
+			return nil, lastErr
+		}
+
+		backoff := computeBackoffDuration(attempt, retryAfter)
+		s.logger.Printf("Slack assistant search retry hash=%s attempt=%d backoff=%s error=%v",
+			queryHash, attempt+1, backoff, err)
+		span.SetAttributes(attribute.String("slack.retry_backoff", backoff.String()))
+		if err := sleepWithContext(ctx, backoff); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "backoff_interrupted")
+			return nil, err
+		}
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("unknown Slack assistant search error")
+	}
+	span.RecordError(lastErr)
+	span.SetStatus(codes.Error, "search_failed")
+	return nil, lastErr
+}
+
+func (s *AssistantSearcher) ensureCircuitAvailable() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.circuitOpenUntil.IsZero() {
+		if remaining := time.Until(s.circuitOpenUntil); remaining > 0 {
+			return fmt.Errorf("slack assistant search circuit open, retry after %s", remaining.Round(time.Second))
+		}
+		s.circuitOpenUntil = time.Time{}
+	}
+	return nil
+}
+
+func (s *AssistantSearcher) recordSuccess() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.consecutiveError = 0
+}
+
+func (s *AssistantSearcher) recordFailure() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.consecutiveError++
+	if s.consecutiveError >= circuitFailureThreshold {
+		s.circuitOpenUntil = time.Now().Add(circuitCooldownDuration)
+		s.logger.Printf("Slack assistant search circuit breaker tripped; cooldown until %s",
+			s.circuitOpenUntil.UTC().Format(time.RFC3339))
+		s.consecutiveError = 0
+	}
+}
+
+func convertAssistantSearchMessage(m slack.AssistantSearchContextMessage) slack.Message {
+	return slack.Message{
+		Msg: slack.Msg{
+			Channel:   m.ChannelID,
+			User:      m.AuthorUserID,
+			Username:  m.AuthorName,
+			Text:      m.Content,
+			Timestamp: m.MessageTS,
+			Permalink: m.Permalink,
+			Blocks:    m.Blocks,
+		},
+	}
+}
+
+// isAssistantFatalError reports whether the Slack error code (if any) is one
+// of the documented fatal conditions for assistant.search.context that
+// should never be retried.
+func isAssistantFatalError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	fatals := []string{
+		"invalid_action_token",
+		"missing_scope",
+		"not_allowed_token_type",
+		"invalid_auth",
+		"token_expired",
+		"token_revoked",
+		"access_denied",
+		"feature_not_enabled",
+		"assistant_search_context_disabled",
+		"context_channel_not_found",
+	}
+	for _, code := range fatals {
+		if strings.Contains(msg, code) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pkg/slacksearch/assistant_searcher.go
+++ b/internal/pkg/slacksearch/assistant_searcher.go
@@ -23,6 +23,8 @@ type assistantSearchClient interface {
 	) (*slack.AssistantSearchContextResponse, error)
 }
 
+const maxAssistantSearchResults = 20
+
 // AssistantSearcher invokes Slack's `assistant.search.context` API on a Bot
 // Token. The caller must surface a short-lived `action_token` obtained from
 // an `app_mention` or `message` event (Real-time Search API). The bot can
@@ -113,7 +115,7 @@ func (s *AssistantSearcher) Search(ctx context.Context, req *SearchRequest) (*Se
 		ActionToken:            req.ActionToken,
 		ChannelTypes:           []string{"public_channel"},
 		ContentTypes:           []string{"messages"},
-		Limit:                  clamp(max(req.MaxResults, defaultSearchResultLimit), minSearchResults, maxSearchResults),
+		Limit:                  clamp(max(req.MaxResults, defaultSearchResultLimit), minSearchResults, maxAssistantSearchResults),
 		IncludeContextMessages: true,
 		Sort:                   "timestamp",
 		SortDir:                "desc",
@@ -163,16 +165,19 @@ func (s *AssistantSearcher) Search(ctx context.Context, req *SearchRequest) (*Se
 	}
 
 	messages := make([]slack.Message, 0, len(resp.Results.Messages))
+	enrichedMessages := make([]EnrichedMessage, 0, len(resp.Results.Messages))
 	for _, match := range resp.Results.Messages {
 		messages = append(messages, convertAssistantSearchMessage(match))
+		enrichedMessages = append(enrichedMessages, convertAssistantSearchEnrichedMessage(match))
 	}
 
 	hasMore := strings.TrimSpace(resp.ResponseMetadata.NextCursor) != ""
 	response := &SearchResponse{
-		Messages:   messages,
-		TotalCount: len(messages),
-		HasMore:    hasMore,
-		Query:      query,
+		Messages:         messages,
+		EnrichedMessages: enrichedMessages,
+		TotalCount:       len(messages),
+		HasMore:          hasMore,
+		Query:            query,
 	}
 
 	span.SetAttributes(
@@ -219,6 +224,12 @@ func (s *AssistantSearcher) SearchWithRetry(ctx context.Context, req *SearchRequ
 		}
 
 		lastErr = err
+		if isAssistantActionTokenError(err) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "non_retryable_action_token_error")
+			return nil, lastErr
+		}
+
 		s.recordFailure()
 
 		if isAssistantFatalError(err) {
@@ -303,15 +314,39 @@ func convertAssistantSearchMessage(m slack.AssistantSearchContextMessage) slack.
 	}
 }
 
+func convertAssistantSearchEnrichedMessage(m slack.AssistantSearchContextMessage) EnrichedMessage {
+	msg := convertAssistantSearchMessage(m)
+	enriched := EnrichedMessage{
+		OriginalMessage: msg,
+		Permalink:       msg.Permalink,
+	}
+	if m.ContextMessages != nil {
+		enriched.PreviousMessages = convertAssistantSearchContextMessages(m.ContextMessages.Before)
+		enriched.NextMessages = convertAssistantSearchContextMessages(m.ContextMessages.After)
+	}
+	return enriched
+}
+
+func convertAssistantSearchContextMessages(messages []slack.AssistantSearchContextMessage) []slack.Message {
+	if len(messages) == 0 {
+		return nil
+	}
+	converted := make([]slack.Message, 0, len(messages))
+	for _, msg := range messages {
+		converted = append(converted, convertAssistantSearchMessage(msg))
+	}
+	return converted
+}
+
+func isAssistantActionTokenError(err error) bool {
+	return assistantErrorContains(err, "invalid_action_token", "token_expired")
+}
+
 // isAssistantFatalError reports whether the Slack error code (if any) is one
 // of the documented fatal conditions for assistant.search.context that
 // should never be retried.
 func isAssistantFatalError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	fatals := []string{
+	return assistantErrorContains(err,
 		"invalid_action_token",
 		"missing_scope",
 		"not_allowed_token_type",
@@ -322,8 +357,15 @@ func isAssistantFatalError(err error) bool {
 		"feature_not_enabled",
 		"assistant_search_context_disabled",
 		"context_channel_not_found",
+	)
+}
+
+func assistantErrorContains(err error, codes ...string) bool {
+	if err == nil {
+		return false
 	}
-	for _, code := range fatals {
+	msg := err.Error()
+	for _, code := range codes {
 		if strings.Contains(msg, code) {
 			return true
 		}

--- a/internal/pkg/slacksearch/assistant_searcher_test.go
+++ b/internal/pkg/slacksearch/assistant_searcher_test.go
@@ -58,6 +58,26 @@ func TestAssistantSearcher_SearchSuccess(t *testing.T) {
 					MessageTS:    "1700000000.000100",
 					Content:      "deployment completed",
 					Permalink:    "https://example.slack.com/archives/C_HIT/p1700000000000100",
+					ContextMessages: &slack.AssistantSearchContextMessageContext{
+						Before: []slack.AssistantSearchContextMessage{
+							{
+								ChannelID:    "C_HIT",
+								AuthorUserID: "U0",
+								AuthorName:   "bob",
+								MessageTS:    "1700000000.000000",
+								Content:      "deployment started",
+							},
+						},
+						After: []slack.AssistantSearchContextMessage{
+							{
+								ChannelID:    "C_HIT",
+								AuthorUserID: "U2",
+								AuthorName:   "carol",
+								MessageTS:    "1700000000.000200",
+								Content:      "smoke tests passed",
+							},
+						},
+					},
 				},
 			},
 		},
@@ -79,6 +99,39 @@ func TestAssistantSearcher_SearchSuccess(t *testing.T) {
 	assert.Equal(t, "deployment completed", got.Text)
 	assert.Equal(t, "1700000000.000100", got.Timestamp)
 	assert.Equal(t, "https://example.slack.com/archives/C_HIT/p1700000000000100", got.Permalink)
+	require.Len(t, resp.EnrichedMessages, 1)
+	enriched := resp.EnrichedMessages[0]
+	assert.Equal(t, got, enriched.OriginalMessage)
+	assert.Equal(t, got.Permalink, enriched.Permalink)
+	require.Len(t, enriched.PreviousMessages, 1)
+	assert.Equal(t, "deployment started", enriched.PreviousMessages[0].Text)
+	require.Len(t, enriched.NextMessages, 1)
+	assert.Equal(t, "smoke tests passed", enriched.NextMessages[0].Text)
+
+	prompt := (&SlackSearchResult{EnrichedMessages: resp.EnrichedMessages}).ForPrompt()
+	assert.Contains(t, prompt, "Previous at")
+	assert.Contains(t, prompt, "deployment started")
+	assert.Contains(t, prompt, "Next at")
+	assert.Contains(t, prompt, "smoke tests passed")
+	client.AssertExpectations(t)
+}
+
+func TestAssistantSearcher_ClampsLimitToAssistantMaximum(t *testing.T) {
+	client := &mockAssistantSearchClient{}
+	s := newTestAssistantSearcher(client)
+
+	client.On("SearchAssistantContextContext", mock.Anything, mock.MatchedBy(func(p slack.AssistantSearchContextParameters) bool {
+		return p.Limit == maxAssistantSearchResults
+	})).Return(&slack.AssistantSearchContextResponse{
+		SlackResponse: slack.SlackResponse{Ok: true},
+	}, nil).Once()
+
+	_, err := s.Search(context.Background(), &SearchRequest{
+		Query:       "deployment",
+		ActionToken: "TK123",
+		MaxResults:  100,
+	})
+	require.NoError(t, err)
 	client.AssertExpectations(t)
 }
 
@@ -132,6 +185,48 @@ func TestAssistantSearcher_FatalErrorFastFails(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid_action_token")
 	client.AssertNumberOfCalls(t, "SearchAssistantContextContext", 1)
+}
+
+func TestAssistantSearcher_ActionTokenErrorsDoNotOpenCircuit(t *testing.T) {
+	client := &mockAssistantSearchClient{}
+	s := newTestAssistantSearcher(client)
+
+	for _, code := range []string{"invalid_action_token", "token_expired", "invalid_action_token"} {
+		client.On("SearchAssistantContextContext", mock.Anything, mock.Anything).
+			Return(&slack.AssistantSearchContextResponse{
+				SlackResponse: slack.SlackResponse{Ok: false, Error: code},
+			}, nil).Once()
+
+		_, err := s.SearchWithRetry(context.Background(), &SearchRequest{
+			Query:       "x",
+			ActionToken: "expired",
+		}, 5)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), code)
+	}
+
+	client.On("SearchAssistantContextContext", mock.Anything, mock.Anything).
+		Return(&slack.AssistantSearchContextResponse{
+			SlackResponse: slack.SlackResponse{Ok: true},
+			Results: slack.AssistantSearchContextResults{
+				Messages: []slack.AssistantSearchContextMessage{
+					{
+						ChannelID:    "C1",
+						AuthorUserID: "U1",
+						MessageTS:    "1700000000.000100",
+						Content:      "ok",
+					},
+				},
+			},
+		}, nil).Once()
+
+	resp, err := s.SearchWithRetry(context.Background(), &SearchRequest{
+		Query:       "x",
+		ActionToken: "fresh",
+	}, 0)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	client.AssertNumberOfCalls(t, "SearchAssistantContextContext", 4)
 }
 
 func TestAssistantSearcher_NotOkBecomesError(t *testing.T) {

--- a/internal/pkg/slacksearch/assistant_searcher_test.go
+++ b/internal/pkg/slacksearch/assistant_searcher_test.go
@@ -1,0 +1,149 @@
+package slacksearch
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockAssistantSearchClient struct {
+	mock.Mock
+}
+
+func (m *mockAssistantSearchClient) SearchAssistantContextContext(
+	ctx context.Context,
+	params slack.AssistantSearchContextParameters,
+) (*slack.AssistantSearchContextResponse, error) {
+	args := m.Called(ctx, params)
+	if r := args.Get(0); r != nil {
+		return r.(*slack.AssistantSearchContextResponse), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func newTestAssistantSearcher(client assistantSearchClient) *AssistantSearcher {
+	s := NewAssistantSearcher(nil, NewRateLimiter(1000, 1000, 1000), 5*time.Second)
+	s.client = client
+	s.logger.SetOutput(io.Discard)
+	return s
+}
+
+func TestAssistantSearcher_SearchSuccess(t *testing.T) {
+	client := &mockAssistantSearchClient{}
+	s := newTestAssistantSearcher(client)
+
+	client.On("SearchAssistantContextContext", mock.Anything, mock.MatchedBy(func(p slack.AssistantSearchContextParameters) bool {
+		// Verify ActionToken, ContextChannelID, channel/content types, time range
+		return p.Query == "deployment" &&
+			p.ActionToken == "TK123" &&
+			p.ContextChannelID == "C_ORIGIN" &&
+			len(p.ChannelTypes) == 1 && p.ChannelTypes[0] == "public_channel" &&
+			len(p.ContentTypes) == 1 && p.ContentTypes[0] == "messages" &&
+			p.IncludeContextMessages
+	})).Return(&slack.AssistantSearchContextResponse{
+		SlackResponse: slack.SlackResponse{Ok: true},
+		Results: slack.AssistantSearchContextResults{
+			Messages: []slack.AssistantSearchContextMessage{
+				{
+					ChannelID:    "C_HIT",
+					ChannelName:  "engineering",
+					AuthorUserID: "U1",
+					AuthorName:   "alice",
+					MessageTS:    "1700000000.000100",
+					Content:      "deployment completed",
+					Permalink:    "https://example.slack.com/archives/C_HIT/p1700000000000100",
+				},
+			},
+		},
+	}, nil).Once()
+
+	resp, err := s.Search(context.Background(), &SearchRequest{
+		Query:            "deployment",
+		ActionToken:      "TK123",
+		ContextChannelID: "C_ORIGIN",
+		MaxResults:       5,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Messages, 1)
+	got := resp.Messages[0]
+	assert.Equal(t, "C_HIT", got.Channel)
+	assert.Equal(t, "U1", got.User)
+	assert.Equal(t, "alice", got.Username)
+	assert.Equal(t, "deployment completed", got.Text)
+	assert.Equal(t, "1700000000.000100", got.Timestamp)
+	assert.Equal(t, "https://example.slack.com/archives/C_HIT/p1700000000000100", got.Permalink)
+	client.AssertExpectations(t)
+}
+
+func TestAssistantSearcher_RejectsMissingActionToken(t *testing.T) {
+	client := &mockAssistantSearchClient{}
+	s := newTestAssistantSearcher(client)
+
+	_, err := s.Search(context.Background(), &SearchRequest{Query: "x", MaxResults: 5})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "action_token is required")
+	client.AssertNotCalled(t, "SearchAssistantContextContext", mock.Anything, mock.Anything)
+}
+
+func TestAssistantSearcher_PassesTimeRangeAsUnix(t *testing.T) {
+	client := &mockAssistantSearchClient{}
+	s := newTestAssistantSearcher(client)
+
+	start := time.Date(2025, 10, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 10, 21, 0, 0, 0, 0, time.UTC)
+
+	client.On("SearchAssistantContextContext", mock.Anything, mock.MatchedBy(func(p slack.AssistantSearchContextParameters) bool {
+		return p.After == start.Unix() && p.Before == end.Unix()
+	})).Return(&slack.AssistantSearchContextResponse{
+		SlackResponse: slack.SlackResponse{Ok: true},
+	}, nil).Once()
+
+	_, err := s.Search(context.Background(), &SearchRequest{
+		Query:       "q",
+		ActionToken: "TK",
+		MaxResults:  5,
+		TimeRange:   &TimeRange{Start: &start, End: &end},
+	})
+	require.NoError(t, err)
+	client.AssertExpectations(t)
+}
+
+func TestAssistantSearcher_FatalErrorFastFails(t *testing.T) {
+	client := &mockAssistantSearchClient{}
+	s := newTestAssistantSearcher(client)
+
+	// Even with retries, an invalid_action_token must not be retried.
+	client.On("SearchAssistantContextContext", mock.Anything, mock.Anything).
+		Return(&slack.AssistantSearchContextResponse{
+			SlackResponse: slack.SlackResponse{Ok: false, Error: "invalid_action_token"},
+		}, nil).Once()
+
+	_, err := s.SearchWithRetry(context.Background(), &SearchRequest{
+		Query:       "x",
+		ActionToken: "expired",
+	}, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid_action_token")
+	client.AssertNumberOfCalls(t, "SearchAssistantContextContext", 1)
+}
+
+func TestAssistantSearcher_NotOkBecomesError(t *testing.T) {
+	client := &mockAssistantSearchClient{}
+	s := newTestAssistantSearcher(client)
+
+	client.On("SearchAssistantContextContext", mock.Anything, mock.Anything).
+		Return(&slack.AssistantSearchContextResponse{
+			SlackResponse: slack.SlackResponse{Ok: false, Error: "missing_scope"},
+		}, nil).Once()
+
+	_, err := s.Search(context.Background(), &SearchRequest{Query: "q", ActionToken: "TK"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing_scope")
+}

--- a/internal/pkg/slacksearch/assistant_searcher_test.go
+++ b/internal/pkg/slacksearch/assistant_searcher_test.go
@@ -116,6 +116,121 @@ func TestAssistantSearcher_SearchSuccess(t *testing.T) {
 	client.AssertExpectations(t)
 }
 
+func TestAssistantSearcher_BotAuthoredResultsAreMarkedForFilter(t *testing.T) {
+	client := &mockAssistantSearchClient{}
+	s := newTestAssistantSearcher(client)
+
+	client.On("SearchAssistantContextContext", mock.Anything, mock.AnythingOfType("slack.AssistantSearchContextParameters")).
+		Return(&slack.AssistantSearchContextResponse{
+			SlackResponse: slack.SlackResponse{Ok: true},
+			Results: slack.AssistantSearchContextResults{
+				Messages: []slack.AssistantSearchContextMessage{
+					{
+						ChannelID:    "C_HIT",
+						AuthorUserID: "B123",
+						AuthorName:   "deploy-bot",
+						MessageTS:    "1700000000.000100",
+						Content:      "bot result",
+						IsAuthorBot:  true,
+					},
+					{
+						ChannelID:    "C_HIT",
+						AuthorUserID: "U1",
+						AuthorName:   "alice",
+						MessageTS:    "1700000000.000200",
+						Content:      "human result",
+					},
+				},
+			},
+		}, nil).Once()
+
+	resp, err := s.Search(context.Background(), &SearchRequest{Query: "deployment", ActionToken: "TK123", MaxResults: 5})
+	require.NoError(t, err)
+	require.Len(t, resp.Messages, 2)
+	assert.True(t, isBotMessage(resp.Messages[0]))
+
+	filteredMessages, filteredEnriched, dropped := filterBotSearchResults(resp.Messages, resp.EnrichedMessages)
+	require.Equal(t, 1, dropped)
+	require.Len(t, filteredMessages, 1)
+	assert.Equal(t, "human result", filteredMessages[0].Text)
+	require.Len(t, filteredEnriched, 1)
+	assert.Equal(t, "human result", filteredEnriched[0].OriginalMessage.Text)
+	client.AssertExpectations(t)
+}
+
+func TestAssistantSearcher_BotAuthoredContextExcludedFromPrompt(t *testing.T) {
+	client := &mockAssistantSearchClient{}
+	s := newTestAssistantSearcher(client)
+
+	client.On("SearchAssistantContextContext", mock.Anything, mock.AnythingOfType("slack.AssistantSearchContextParameters")).
+		Return(&slack.AssistantSearchContextResponse{
+			SlackResponse: slack.SlackResponse{Ok: true},
+			Results: slack.AssistantSearchContextResults{
+				Messages: []slack.AssistantSearchContextMessage{
+					{
+						ChannelID:    "C_HIT",
+						AuthorUserID: "U1",
+						AuthorName:   "alice",
+						MessageTS:    "1700000000.000100",
+						Content:      "deployment completed",
+						ContextMessages: &slack.AssistantSearchContextMessageContext{
+							Before: []slack.AssistantSearchContextMessage{
+								{
+									ChannelID:    "C_HIT",
+									AuthorUserID: "B123",
+									AuthorName:   "deploy-bot",
+									MessageTS:    "1700000000.000000",
+									Content:      "bot before context",
+									IsAuthorBot:  true,
+								},
+								{
+									ChannelID:    "C_HIT",
+									AuthorUserID: "U2",
+									AuthorName:   "bob",
+									MessageTS:    "1700000000.000050",
+									Content:      "human before context",
+								},
+							},
+							After: []slack.AssistantSearchContextMessage{
+								{
+									ChannelID:    "C_HIT",
+									AuthorUserID: "B456",
+									AuthorName:   "deploy-bot",
+									MessageTS:    "1700000000.000150",
+									Content:      "bot after context",
+									IsAuthorBot:  true,
+								},
+								{
+									ChannelID:    "C_HIT",
+									AuthorUserID: "U3",
+									AuthorName:   "carol",
+									MessageTS:    "1700000000.000200",
+									Content:      "human after context",
+								},
+							},
+						},
+					},
+				},
+			},
+		}, nil).Once()
+
+	resp, err := s.Search(context.Background(), &SearchRequest{Query: "deployment", ActionToken: "TK123", MaxResults: 5})
+	require.NoError(t, err)
+	require.Len(t, resp.EnrichedMessages, 1)
+	enriched := resp.EnrichedMessages[0]
+	require.Len(t, enriched.PreviousMessages, 1)
+	require.Len(t, enriched.NextMessages, 1)
+	assert.Equal(t, "human before context", enriched.PreviousMessages[0].Text)
+	assert.Equal(t, "human after context", enriched.NextMessages[0].Text)
+
+	prompt := (&SlackSearchResult{EnrichedMessages: resp.EnrichedMessages}).ForPrompt()
+	assert.NotContains(t, prompt, "bot before context")
+	assert.NotContains(t, prompt, "bot after context")
+	assert.Contains(t, prompt, "human before context")
+	assert.Contains(t, prompt, "human after context")
+	client.AssertExpectations(t)
+}
+
 func TestAssistantSearcher_ClampsLimitToAssistantMaximum(t *testing.T) {
 	client := &mockAssistantSearchClient{}
 	s := newTestAssistantSearcher(client)

--- a/internal/pkg/slacksearch/searcher.go
+++ b/internal/pkg/slacksearch/searcher.go
@@ -45,6 +45,14 @@ type SearchRequest struct {
 	Query      string
 	TimeRange  *TimeRange
 	MaxResults int
+	// ActionToken propagates the Real-time Search API action token from the
+	// originating Slack event. Only consumed by the assistant.search.context
+	// searcher; legacy search.messages searcher ignores it.
+	ActionToken string
+	// ContextChannelID is the Slack channel ID in which the originating event
+	// occurred. assistant.search.context uses it as a scoping hint when the
+	// caller is inside a Slack Connect channel.
+	ContextChannelID string
 }
 
 // SearchResponse contains the Slack search results and metadata.

--- a/internal/pkg/slacksearch/searcher.go
+++ b/internal/pkg/slacksearch/searcher.go
@@ -57,10 +57,11 @@ type SearchRequest struct {
 
 // SearchResponse contains the Slack search results and metadata.
 type SearchResponse struct {
-	Messages   []slack.Message
-	TotalCount int
-	HasMore    bool
-	Query      string
+	Messages         []slack.Message
+	EnrichedMessages []EnrichedMessage
+	TotalCount       int
+	HasMore          bool
+	Query            string
 }
 
 // NewSearcher constructs a new Searcher instance.

--- a/internal/pkg/slacksearch/service.go
+++ b/internal/pkg/slacksearch/service.go
@@ -35,14 +35,25 @@ type slackSufficiencyChecker interface {
 }
 
 // SlackSearchService orchestrates the Slack search pipeline.
+//
+// It can dispatch a search to either of two backends, chosen per-call based
+// on SearchOptions.ActionToken:
+//
+//   - userSearcher       — legacy `search.messages` over a User Token (xoxp);
+//     required by CLI/MCP because they have no `action_token`.
+//   - assistantSearcher  — Real-time Search API (`assistant.search.context`)
+//     over the Bot Token (xoxb) plus a short-lived `action_token` obtained
+//     from an `app_mention` / `message` event. Lets the bot reach public
+//     channels it has not been invited to.
 type SlackSearchService struct {
 	botClient          *slack.Client
-	userClient         *slack.Client
+	userClient         *slack.Client // nil unless SLACK_USER_TOKEN is set
 	queryGenerator     slackQueryGenerator
-	searcher           slackSearcher
-	contextRetriever   slackContextRetriever
+	userSearcher       slackSearcher         // search.messages; nil without user token
+	assistantSearcher  slackSearcher         // assistant.search.context; nil if bot client missing
+	contextRetriever   slackContextRetriever // requires user token
 	sufficiencyChecker slackSufficiencyChecker
-	messageFetcher     *MessageFetcher
+	messageFetcher     *MessageFetcher // URL fetch; user token preferred, bot token fallback
 	config             *SlackSearchConfig
 	logger             *log.Logger
 	progressHandler    func(iteration int, maxIterations int)
@@ -90,17 +101,20 @@ func NewSlackSearchService(
 	if strings.TrimSpace(cfg.UserToken) == "" {
 		cfg.UserToken = os.Getenv("SLACK_USER_TOKEN")
 	}
-	if cfg.Enabled && strings.TrimSpace(cfg.UserToken) == "" {
-		return nil, fmt.Errorf("SLACK_USER_TOKEN must be set when Slack search is enabled")
-	}
 
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid Slack search configuration: %w", err)
 	}
 
+	// Build the user-token client (search.messages backend) when xoxp is set.
+	// The bot token is always available (validated above); the assistant
+	// searcher uses it together with a per-request action_token.
 	var userClient *slack.Client
 	if strings.TrimSpace(cfg.UserToken) != "" {
 		userClient = slack.New(cfg.UserToken)
+	} else if cfg.Enabled {
+		logger.Printf("Slack search: SLACK_USER_TOKEN not set; user-token backend (search.messages) is disabled, " +
+			"slack-bot mention path can still use assistant.search.context with action_token")
 	}
 
 	searchLimiter := NewRateLimiter(20, 20, 20)
@@ -109,22 +123,31 @@ func NewSlackSearchService(
 	llmTimeout := time.Duration(cfg.LLMTimeoutSeconds) * time.Second
 	queryGenerator := NewQueryGenerator(bedrockClient, llmTimeout)
 
+	requestTimeout := time.Duration(cfg.TimeoutSeconds) * time.Second
+
 	var (
-		searcher         slackSearcher
+		userSearcher     slackSearcher
 		contextRetriever slackContextRetriever
 		messageFetcher   *MessageFetcher
-		err              error
 	)
 
 	if userClient != nil {
-		requestTimeout := time.Duration(cfg.TimeoutSeconds) * time.Second
-		searcher = NewSearcher(userClient, searchLimiter, requestTimeout)
+		userSearcher = NewSearcher(userClient, searchLimiter, requestTimeout)
+		var err error
 		contextRetriever, err = NewContextRetriever(userClient, contextLimiter, bedrockClient, cfg, logger)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create context retriever: %w", err)
 		}
 		messageFetcher = NewMessageFetcher(userClient, contextLimiter, cfg, logger)
+	} else {
+		// URL fetch over the bot token still works for channels the bot is
+		// invited to (channels:history scope). It is the only viable path
+		// when SLACK_USER_TOKEN is not configured.
+		messageFetcher = NewMessageFetcher(botClient, contextLimiter, cfg, logger)
 	}
+
+	// assistant.search.context always uses the bot token + action_token.
+	assistantSearcher := NewAssistantSearcher(botClient, searchLimiter, requestTimeout)
 
 	sufficiencyChecker := NewSufficiencyChecker(bedrockClient, logger, llmTimeout)
 
@@ -132,7 +155,8 @@ func NewSlackSearchService(
 		botClient:          botClient,
 		userClient:         userClient,
 		queryGenerator:     queryGenerator,
-		searcher:           searcher,
+		userSearcher:       userSearcher,
+		assistantSearcher:  assistantSearcher,
 		contextRetriever:   contextRetriever,
 		sufficiencyChecker: sufficiencyChecker,
 		messageFetcher:     messageFetcher,
@@ -183,16 +207,57 @@ func (s *SlackSearchService) HealthCheck(ctx context.Context) error {
 		return fmt.Errorf("SLACK_BOT_TOKEN must be set when Slack search is enabled")
 	}
 
-	if s.userClient == nil {
-		return fmt.Errorf("slack user client is not configured")
+	if s.userSearcher == nil && s.assistantSearcher == nil {
+		return fmt.Errorf("slack realtime search client is not configured (no user token and no bot token)")
 	}
 
 	s.logger.Printf("Slack search health check passed")
 	return nil
 }
 
+// SearchBackend identifies which Slack search API the service ended up using.
+type SearchBackend string
+
+const (
+	// SearchBackendUser uses search.messages over a user token.
+	SearchBackendUser SearchBackend = "user_search_messages"
+	// SearchBackendAssistant uses assistant.search.context over a bot token
+	// plus an action_token surfaced by a Slack event.
+	SearchBackendAssistant SearchBackend = "assistant_search_context"
+)
+
+// selectSearcher picks the active searcher for this call.
+//
+// Priority:
+//  1. opts.ActionToken set + assistantSearcher available → assistant path.
+//     This lets a slack-bot mention reach public channels the bot is not in.
+//  2. userSearcher available → legacy search.messages path.
+//  3. otherwise → caller error.
+func (s *SlackSearchService) selectSearcher(opts SearchOptions) (slackSearcher, SearchBackend, error) {
+	if strings.TrimSpace(opts.ActionToken) != "" && s.assistantSearcher != nil {
+		return s.assistantSearcher, SearchBackendAssistant, nil
+	}
+	if s.userSearcher != nil {
+		return s.userSearcher, SearchBackendUser, nil
+	}
+	return nil, "", fmt.Errorf(
+		"slack search requires either SLACK_USER_TOKEN (legacy search.messages) " +
+			"or a Slack event action_token (assistant.search.context)")
+}
+
 // Search executes the Slack search pipeline.
-func (s *SlackSearchService) Search(ctx context.Context, userQuery string, channels []string) (*SlackSearchResult, error) {
+//
+// opts.ActionToken decides the backend at call time. When non-empty and the
+// bot client is available, the service uses `assistant.search.context`
+// against the bot token, which can reach public channels even if the bot has
+// not been invited. Otherwise it falls back to the legacy `search.messages`
+// flow against SLACK_USER_TOKEN.
+func (s *SlackSearchService) Search(
+	ctx context.Context,
+	userQuery string,
+	channels []string,
+	opts SearchOptions,
+) (*SlackSearchResult, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -204,8 +269,10 @@ func (s *SlackSearchService) Search(ctx context.Context, userQuery string, chann
 	span.SetAttributes(
 		attribute.String("slack.query_hash", queryHash),
 		attribute.Int("slack.channel_count", len(channels)),
+		attribute.Bool("slack.has_action_token", strings.TrimSpace(opts.ActionToken) != ""),
 	)
-	s.logger.Printf("Slack search started hash=%s channels=%d enabled=%t", queryHash, len(channels), s.config.Enabled)
+	s.logger.Printf("Slack search started hash=%s channels=%d enabled=%t has_action_token=%t",
+		queryHash, len(channels), s.config.Enabled, strings.TrimSpace(opts.ActionToken) != "")
 
 	if !s.config.Enabled {
 		err := fmt.Errorf("slack search is disabled in configuration")
@@ -213,7 +280,7 @@ func (s *SlackSearchService) Search(ctx context.Context, userQuery string, chann
 		span.SetStatus(codes.Error, "slack_search_disabled")
 		return nil, err
 	}
-	if s.queryGenerator == nil || s.searcher == nil || s.contextRetriever == nil || s.sufficiencyChecker == nil {
+	if s.queryGenerator == nil || s.sufficiencyChecker == nil {
 		err := fmt.Errorf("slack search service not fully initialized")
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "service_not_initialized")
@@ -225,6 +292,15 @@ func (s *SlackSearchService) Search(ctx context.Context, userQuery string, chann
 		span.SetStatus(codes.Error, "invalid_query")
 		return nil, err
 	}
+
+	activeSearcher, backend, err := s.selectSearcher(opts)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "no_searcher_available")
+		return nil, err
+	}
+	span.SetAttributes(attribute.String("slack.search_backend", string(backend)))
+	s.logger.Printf("Slack search backend=%s hash=%s", backend, queryHash)
 
 	startTime := time.Now()
 
@@ -305,6 +381,8 @@ func (s *SlackSearchService) Search(ctx context.Context, userQuery string, chann
 
 		searchMessages, _, executedQueries, previousQueries, _, err = s.runSearchIteration(
 			iterationCtx,
+			activeSearcher,
+			opts,
 			userQuery,
 			channels,
 			previousQueries,
@@ -384,19 +462,35 @@ func (s *SlackSearchService) Search(ctx context.Context, userQuery string, chann
 			return result, nil
 		}
 
-		contextResp, err := s.contextRetriever.RetrieveContext(iterationCtx, &ContextRequest{
-			Messages:  searchMessages,
-			UserQuery: userQuery,
-		})
-		if err != nil {
-			s.logger.Printf("Slack search context retrieval failed: %v", err)
-			iterSpan.AddEvent("context_retrieval_failed", trace.WithAttributes(attribute.String("error", err.Error())))
+		// assistant.search.context already returns permalinks and (eventually)
+		// inline context_messages, so we skip the ContextRetriever — its
+		// underlying APIs (conversations.history/replies) require the bot to
+		// be a channel member, which defeats the whole point of using the
+		// assistant path. The bot path therefore exposes only the matched
+		// messages plus their permalinks.
+		var contextResp *ContextResponse
+		switch {
+		case backend == SearchBackendAssistant, s.contextRetriever == nil:
 			contextResp = &ContextResponse{
 				EnrichedMessages: s.fallbackEnriched(searchMessages),
 				TotalRetrieved:   len(searchMessages),
 			}
-		} else {
-			s.logger.Printf("Slack search context retrieved hash=%s retrieved=%d", queryHash, contextResp.TotalRetrieved)
+		default:
+			var retrieveErr error
+			contextResp, retrieveErr = s.contextRetriever.RetrieveContext(iterationCtx, &ContextRequest{
+				Messages:  searchMessages,
+				UserQuery: userQuery,
+			})
+			if retrieveErr != nil {
+				s.logger.Printf("Slack search context retrieval failed: %v", retrieveErr)
+				iterSpan.AddEvent("context_retrieval_failed", trace.WithAttributes(attribute.String("error", retrieveErr.Error())))
+				contextResp = &ContextResponse{
+					EnrichedMessages: s.fallbackEnriched(searchMessages),
+					TotalRetrieved:   len(searchMessages),
+				}
+			} else {
+				s.logger.Printf("Slack search context retrieved hash=%s retrieved=%d", queryHash, contextResp.TotalRetrieved)
+			}
 		}
 
 		enrichedMessages = contextResp.EnrichedMessages
@@ -489,6 +583,8 @@ func (s *SlackSearchService) Search(ctx context.Context, userQuery string, chann
 
 func (s *SlackSearchService) runSearchIteration(
 	ctx context.Context,
+	activeSearcher slackSearcher,
+	opts SearchOptions,
 	userQuery string,
 	channels []string,
 	previousQueries []string,
@@ -528,7 +624,7 @@ func (s *SlackSearchService) runSearchIteration(
 	s.logger.Printf("Slack search iteration=%d hash=%s generated_queries=%d time_filter=%t",
 		iteration+1, queryHash, len(genResp.Queries), genResp.TimeFilter != nil)
 
-	searchMessages, totalMatches, executedQueries = s.executeSlackSearch(ctx, genResp, executedQueries)
+	searchMessages, totalMatches, executedQueries = s.executeSlackSearch(ctx, activeSearcher, opts, genResp, executedQueries)
 	previousQueries = append(previousQueries, genResp.Queries...)
 	previousResults = totalMatches
 
@@ -537,6 +633,8 @@ func (s *SlackSearchService) runSearchIteration(
 
 func (s *SlackSearchService) executeSlackSearch(
 	ctx context.Context,
+	activeSearcher slackSearcher,
+	opts SearchOptions,
 	genResp *QueryGenerationResponse,
 	executedQueries []string,
 ) ([]slack.Message, int, []string) {
@@ -560,12 +658,14 @@ func (s *SlackSearchService) executeSlackSearch(
 		}
 
 		request := &SearchRequest{
-			Query:      query,
-			TimeRange:  genResp.TimeFilter,
-			MaxResults: s.config.MaxResults,
+			Query:            query,
+			TimeRange:        genResp.TimeFilter,
+			MaxResults:       s.config.MaxResults,
+			ActionToken:      opts.ActionToken,
+			ContextChannelID: opts.ChannelID,
 		}
 
-		response, err := s.searcher.SearchWithRetry(ctx, request, s.config.MaxRetries)
+		response, err := activeSearcher.SearchWithRetry(ctx, request, s.config.MaxRetries)
 		executedQueries = append(executedQueries, query)
 		if err != nil {
 			s.logger.Printf("Slack search query failed hash=%s error=%v", telemetryFingerprint(query), err)

--- a/internal/pkg/slacksearch/service.go
+++ b/internal/pkg/slacksearch/service.go
@@ -36,15 +36,16 @@ type slackSufficiencyChecker interface {
 
 // SlackSearchService orchestrates the Slack search pipeline.
 //
-// It can dispatch a search to either of two backends, chosen per-call based
-// on SearchOptions.ActionToken:
+// It can dispatch a search to either of two backends, chosen per-call with
+// the user-token backend taking priority when it is configured:
 //
 //   - userSearcher       — legacy `search.messages` over a User Token (xoxp);
-//     required by CLI/MCP because they have no `action_token`.
+//     preferred whenever SLACK_USER_TOKEN is configured, including Slack bot
+//     events that also carry an `action_token`.
 //   - assistantSearcher  — Real-time Search API (`assistant.search.context`)
 //     over the Bot Token (xoxb) plus a short-lived `action_token` obtained
-//     from an `app_mention` / `message` event. Lets the bot reach public
-//     channels it has not been invited to.
+//     from an `app_mention` / `message` event. Used only when the user-token
+//     backend is unavailable.
 type SlackSearchService struct {
 	botClient          *slack.Client
 	userClient         *slack.Client // nil unless SLACK_USER_TOKEN is set
@@ -229,16 +230,15 @@ const (
 // selectSearcher picks the active searcher for this call.
 //
 // Priority:
-//  1. opts.ActionToken set + assistantSearcher available → assistant path.
-//     This lets a slack-bot mention reach public channels the bot is not in.
-//  2. userSearcher available → legacy search.messages path.
+//  1. userSearcher available → legacy search.messages path.
+//  2. opts.ActionToken set + assistantSearcher available → assistant path.
 //  3. otherwise → caller error.
 func (s *SlackSearchService) selectSearcher(opts SearchOptions) (slackSearcher, SearchBackend, error) {
-	if strings.TrimSpace(opts.ActionToken) != "" && s.assistantSearcher != nil {
-		return s.assistantSearcher, SearchBackendAssistant, nil
-	}
 	if s.userSearcher != nil {
 		return s.userSearcher, SearchBackendUser, nil
+	}
+	if strings.TrimSpace(opts.ActionToken) != "" && s.assistantSearcher != nil {
+		return s.assistantSearcher, SearchBackendAssistant, nil
 	}
 	return nil, "", fmt.Errorf(
 		"slack search requires either SLACK_USER_TOKEN (legacy search.messages) " +
@@ -247,11 +247,10 @@ func (s *SlackSearchService) selectSearcher(opts SearchOptions) (slackSearcher, 
 
 // Search executes the Slack search pipeline.
 //
-// opts.ActionToken decides the backend at call time. When non-empty and the
-// bot client is available, the service uses `assistant.search.context`
-// against the bot token, which can reach public channels even if the bot has
-// not been invited. Otherwise it falls back to the legacy `search.messages`
-// flow against SLACK_USER_TOKEN.
+// SLACK_USER_TOKEN decides the backend first: when the user-token backend is
+// configured, the service uses `search.messages` even if opts.ActionToken is
+// present. The assistant backend is used only when the user-token backend is
+// unavailable and opts.ActionToken is non-empty.
 func (s *SlackSearchService) Search(
 	ctx context.Context,
 	userQuery string,
@@ -374,12 +373,13 @@ func (s *SlackSearchService) Search(
 		}
 
 		var (
-			searchMessages []slack.Message
-			matches        int
-			err            error
+			searchMessages         []slack.Message
+			searchEnrichedMessages []EnrichedMessage
+			matches                int
+			err                    error
 		)
 
-		searchMessages, _, executedQueries, previousQueries, _, err = s.runSearchIteration(
+		searchMessages, searchEnrichedMessages, _, executedQueries, previousQueries, _, err = s.runSearchIteration(
 			iterationCtx,
 			activeSearcher,
 			opts,
@@ -402,7 +402,7 @@ func (s *SlackSearchService) Search(
 			return nil, err
 		}
 
-		searchMessages, botFiltered := filterBotMessages(searchMessages)
+		searchMessages, searchEnrichedMessages, botFiltered := filterBotSearchResults(searchMessages, searchEnrichedMessages)
 		if botFiltered > 0 {
 			iterSpan.SetAttributes(attribute.Int("slack.filtered_bot_messages", botFiltered))
 			s.logger.Printf("Slack search iteration=%d hash=%s filtered_bot_messages=%d", iterationsDone, queryHash, botFiltered)
@@ -462,15 +462,22 @@ func (s *SlackSearchService) Search(
 			return result, nil
 		}
 
-		// assistant.search.context already returns permalinks and (eventually)
-		// inline context_messages, so we skip the ContextRetriever — its
+		// assistant.search.context already returns permalinks and inline
+		// context_messages, so we skip the ContextRetriever — its
 		// underlying APIs (conversations.history/replies) require the bot to
 		// be a channel member, which defeats the whole point of using the
-		// assistant path. The bot path therefore exposes only the matched
-		// messages plus their permalinks.
+		// assistant path.
 		var contextResp *ContextResponse
 		switch {
-		case backend == SearchBackendAssistant, s.contextRetriever == nil:
+		case backend == SearchBackendAssistant:
+			if len(searchEnrichedMessages) == 0 {
+				searchEnrichedMessages = s.fallbackEnriched(searchMessages)
+			}
+			contextResp = &ContextResponse{
+				EnrichedMessages: searchEnrichedMessages,
+				TotalRetrieved:   len(searchEnrichedMessages),
+			}
+		case s.contextRetriever == nil:
 			contextResp = &ContextResponse{
 				EnrichedMessages: s.fallbackEnriched(searchMessages),
 				TotalRetrieved:   len(searchMessages),
@@ -591,12 +598,13 @@ func (s *SlackSearchService) runSearchIteration(
 	previousResults int,
 	executedQueries []string,
 	iteration int,
-) ([]slack.Message, int, []string, []string, int, error) {
+) ([]slack.Message, []EnrichedMessage, int, []string, []string, int, error) {
 	var (
-		searchMessages []slack.Message
-		totalMatches   int
-		genResp        *QueryGenerationResponse
-		err            error
+		searchMessages         []slack.Message
+		searchEnrichedMessages []EnrichedMessage
+		totalMatches           int
+		genResp                *QueryGenerationResponse
+		err                    error
 	)
 	queryHash := telemetryFingerprint(userQuery)
 
@@ -613,22 +621,22 @@ func (s *SlackSearchService) runSearchIteration(
 		genResp, err = s.queryGenerator.GenerateAlternativeQueries(ctx, genReq)
 	}
 	if err != nil {
-		return nil, 0, executedQueries, previousQueries, previousResults, fmt.Errorf("failed to generate Slack queries: %w", err)
+		return nil, nil, 0, executedQueries, previousQueries, previousResults, fmt.Errorf("failed to generate Slack queries: %w", err)
 	}
 
 	if len(genResp.Queries) == 0 {
 		s.logger.Printf("Slack search iteration=%d hash=%s generated_zero_queries", iteration+1, queryHash)
-		return searchMessages, totalMatches, executedQueries, previousQueries, previousResults, nil
+		return searchMessages, searchEnrichedMessages, totalMatches, executedQueries, previousQueries, previousResults, nil
 	}
 
 	s.logger.Printf("Slack search iteration=%d hash=%s generated_queries=%d time_filter=%t",
 		iteration+1, queryHash, len(genResp.Queries), genResp.TimeFilter != nil)
 
-	searchMessages, totalMatches, executedQueries = s.executeSlackSearch(ctx, activeSearcher, opts, genResp, executedQueries)
+	searchMessages, searchEnrichedMessages, totalMatches, executedQueries = s.executeSlackSearch(ctx, activeSearcher, opts, genResp, executedQueries)
 	previousQueries = append(previousQueries, genResp.Queries...)
 	previousResults = totalMatches
 
-	return searchMessages, totalMatches, executedQueries, previousQueries, previousResults, nil
+	return searchMessages, searchEnrichedMessages, totalMatches, executedQueries, previousQueries, previousResults, nil
 }
 
 func (s *SlackSearchService) executeSlackSearch(
@@ -637,9 +645,10 @@ func (s *SlackSearchService) executeSlackSearch(
 	opts SearchOptions,
 	genResp *QueryGenerationResponse,
 	executedQueries []string,
-) ([]slack.Message, int, []string) {
+) ([]slack.Message, []EnrichedMessage, int, []string) {
 	messageMap := make(map[string]slack.Message)
 	messages := make([]slack.Message, 0)
+	enrichedMessages := make([]EnrichedMessage, 0)
 	totalMatches := 0
 
 	limit := s.config.MaxResults
@@ -653,7 +662,7 @@ func (s *SlackSearchService) executeSlackSearch(
 	for _, query := range genResp.Queries {
 		select {
 		case <-ctx.Done():
-			return messages, totalMatches, executedQueries
+			return messages, enrichedMessages, totalMatches, executedQueries
 		default:
 		}
 
@@ -674,20 +683,30 @@ func (s *SlackSearchService) executeSlackSearch(
 
 		totalMatches += response.TotalCount
 		s.logger.Printf("Slack search query succeeded hash=%s matches=%d total_matches=%d", telemetryFingerprint(query), len(response.Messages), totalMatches)
-		for _, msg := range response.Messages {
+		responseMessages := response.Messages
+		if len(responseMessages) == 0 && len(response.EnrichedMessages) > 0 {
+			responseMessages = originalMessagesFromEnriched(response.EnrichedMessages)
+		}
+		enrichedByKey := enrichedMessagesByKey(response.EnrichedMessages)
+		for _, msg := range responseMessages {
 			key := fmt.Sprintf("%s:%s", msg.Channel, msg.Timestamp)
 			if _, exists := messageMap[key]; exists {
 				continue
 			}
 			messageMap[key] = msg
 			messages = append(messages, msg)
+			if enrichedMsg, ok := enrichedByKey[key]; ok {
+				enrichedMessages = append(enrichedMessages, enrichedMsg)
+			} else if len(response.EnrichedMessages) > 0 {
+				enrichedMessages = append(enrichedMessages, EnrichedMessage{OriginalMessage: msg, Permalink: msg.Permalink})
+			}
 			if len(messages) >= limit {
 				break
 			}
 		}
 	}
 
-	return messages, totalMatches, executedQueries
+	return messages, enrichedMessages, totalMatches, executedQueries
 }
 
 func (s *SlackSearchService) fallbackEnriched(messages []slack.Message) []EnrichedMessage {
@@ -695,9 +714,27 @@ func (s *SlackSearchService) fallbackEnriched(messages []slack.Message) []Enrich
 	for _, msg := range messages {
 		enriched = append(enriched, EnrichedMessage{
 			OriginalMessage: msg,
+			Permalink:       msg.Permalink,
 		})
 	}
 	return enriched
+}
+
+func originalMessagesFromEnriched(enriched []EnrichedMessage) []slack.Message {
+	messages := make([]slack.Message, 0, len(enriched))
+	for _, msg := range enriched {
+		messages = append(messages, msg.OriginalMessage)
+	}
+	return messages
+}
+
+func enrichedMessagesByKey(enriched []EnrichedMessage) map[string]EnrichedMessage {
+	byKey := make(map[string]EnrichedMessage, len(enriched))
+	for _, msg := range enriched {
+		key := fmt.Sprintf("%s:%s", msg.OriginalMessage.Channel, msg.OriginalMessage.Timestamp)
+		byKey[key] = msg
+	}
+	return byKey
 }
 
 func (s *SlackSearchService) buildResult(
@@ -738,6 +775,24 @@ func (s *SlackSearchService) buildResult(
 	}
 
 	return result
+}
+
+func filterBotSearchResults(messages []slack.Message, enriched []EnrichedMessage) ([]slack.Message, []EnrichedMessage, int) {
+	filteredMessages, dropped := filterBotMessages(messages)
+	if len(enriched) == 0 || dropped == 0 {
+		return filteredMessages, enriched, dropped
+	}
+
+	enrichedByKey := enrichedMessagesByKey(enriched)
+	filteredEnriched := make([]EnrichedMessage, 0, len(filteredMessages))
+	for _, msg := range filteredMessages {
+		key := fmt.Sprintf("%s:%s", msg.Channel, msg.Timestamp)
+		if enrichedMsg, ok := enrichedByKey[key]; ok {
+			filteredEnriched = append(filteredEnriched, enrichedMsg)
+		}
+	}
+
+	return filteredMessages, filteredEnriched, dropped
 }
 
 func filterBotMessages(messages []slack.Message) ([]slack.Message, int) {

--- a/internal/pkg/slacksearch/service_test.go
+++ b/internal/pkg/slacksearch/service_test.go
@@ -100,7 +100,7 @@ func TestSlackSearchService_SearchSuccess(t *testing.T) {
 	suff := &mockSufficiencyChecker{}
 
 	service.queryGenerator = qg
-	service.searcher = searcher
+	service.userSearcher = searcher
 	service.contextRetriever = context
 	service.sufficiencyChecker = suff
 
@@ -130,7 +130,7 @@ func TestSlackSearchService_SearchSuccess(t *testing.T) {
 	suff.On("Check", mock.Anything, mock.AnythingOfType("*slacksearch.SufficiencyRequest")).
 		Return(&SufficiencyResponse{IsSufficient: true, MissingInfo: nil, Confidence: 0.8}, nil).Once()
 
-	result, err := service.Search(contextBackground(), "How did the deployment go?", []string{"general"})
+	result, err := service.Search(contextBackground(), "How did the deployment go?", []string{"general"}, SearchOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.True(t, result.IsSufficient)
@@ -157,7 +157,7 @@ func TestSlackSearchService_SearchIterativeRefinement(t *testing.T) {
 	suff := &mockSufficiencyChecker{}
 
 	service.queryGenerator = qg
-	service.searcher = searcher
+	service.userSearcher = searcher
 	service.contextRetriever = context
 	service.sufficiencyChecker = suff
 
@@ -183,7 +183,7 @@ func TestSlackSearchService_SearchIterativeRefinement(t *testing.T) {
 	suff.On("Check", mock.Anything, mock.AnythingOfType("*slacksearch.SufficiencyRequest")).
 		Return(&SufficiencyResponse{IsSufficient: true, MissingInfo: nil}, nil).Once()
 
-	result, err := service.Search(contextBackground(), "Summarize the incident", nil)
+	result, err := service.Search(contextBackground(), "Summarize the incident", nil, SearchOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, 2, result.IterationCount)
@@ -204,7 +204,7 @@ func TestSlackSearchService_SearchNoResults(t *testing.T) {
 	searcher := &mockSearcher{}
 
 	service.queryGenerator = qg
-	service.searcher = searcher
+	service.userSearcher = searcher
 	service.contextRetriever = &mockContextRetriever{}
 	service.sufficiencyChecker = &mockSufficiencyChecker{}
 
@@ -213,7 +213,7 @@ func TestSlackSearchService_SearchNoResults(t *testing.T) {
 	searcher.On("SearchWithRetry", mock.Anything, mock.AnythingOfType("*slacksearch.SearchRequest"), cfg.MaxRetries).
 		Return(&SearchResponse{Messages: nil, TotalCount: 0}, nil).Once()
 
-	result, err := service.Search(contextBackground(), "Question with no matches", nil)
+	result, err := service.Search(contextBackground(), "Question with no matches", nil, SearchOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.False(t, result.IsSufficient)
@@ -233,7 +233,7 @@ func TestSlackSearchService_SearchHandlesSearchErrors(t *testing.T) {
 	searcher := &mockSearcher{}
 
 	service.queryGenerator = qg
-	service.searcher = searcher
+	service.userSearcher = searcher
 	service.contextRetriever = &mockContextRetriever{}
 	service.sufficiencyChecker = &mockSufficiencyChecker{}
 
@@ -242,7 +242,7 @@ func TestSlackSearchService_SearchHandlesSearchErrors(t *testing.T) {
 	searcher.On("SearchWithRetry", mock.Anything, mock.AnythingOfType("*slacksearch.SearchRequest"), cfg.MaxRetries).
 		Return(nil, assert.AnError).Once()
 
-	result, err := service.Search(contextBackground(), "Failing query", nil)
+	result, err := service.Search(contextBackground(), "Failing query", nil, SearchOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.False(t, result.IsSufficient)
@@ -263,7 +263,7 @@ func TestSlackSearchService_SearchRespectsContextCancellation(t *testing.T) {
 	suff := &mockSufficiencyChecker{}
 
 	service.queryGenerator = qg
-	service.searcher = searcher
+	service.userSearcher = searcher
 	service.contextRetriever = contextRetriever
 	service.sufficiencyChecker = suff
 
@@ -289,7 +289,7 @@ func TestSlackSearchService_SearchRespectsContextCancellation(t *testing.T) {
 		cancel()
 	}).Return(&SufficiencyResponse{IsSufficient: false, MissingInfo: []string{"Need more"}}, nil).Once()
 
-	result, err := service.Search(ctx, "Cancel after first iteration", nil)
+	result, err := service.Search(ctx, "Cancel after first iteration", nil, SearchOptions{})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, context.Canceled))
 	assert.Nil(t, result)
@@ -302,4 +302,105 @@ func TestSlackSearchService_SearchRespectsContextCancellation(t *testing.T) {
 
 func contextBackground() context.Context {
 	return context.Background()
+}
+
+// --- selectSearcher / dispatch tests ---
+
+func TestSlackSearchService_SelectSearcherUsesAssistantWhenActionToken(t *testing.T) {
+	s := newTestService(defaultConfig())
+	userS := &mockSearcher{}
+	asstS := &mockSearcher{}
+	s.userSearcher = userS
+	s.assistantSearcher = asstS
+
+	sr, backend, err := s.selectSearcher(SearchOptions{ActionToken: "TK"})
+	require.NoError(t, err)
+	assert.Equal(t, SearchBackendAssistant, backend)
+	// Compare interface identity by type assertion to *mockSearcher.
+	gotMock, ok := sr.(*mockSearcher)
+	require.True(t, ok)
+	assert.Same(t, asstS, gotMock)
+}
+
+func TestSlackSearchService_SelectSearcherFallsBackToUserWithoutActionToken(t *testing.T) {
+	s := newTestService(defaultConfig())
+	userS := &mockSearcher{}
+	asstS := &mockSearcher{}
+	s.userSearcher = userS
+	s.assistantSearcher = asstS
+
+	sr, backend, err := s.selectSearcher(SearchOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, SearchBackendUser, backend)
+	gotMock, ok := sr.(*mockSearcher)
+	require.True(t, ok)
+	assert.Same(t, userS, gotMock)
+}
+
+func TestSlackSearchService_SelectSearcherActionTokenButNoAssistantUsesUser(t *testing.T) {
+	s := newTestService(defaultConfig())
+	userS := &mockSearcher{}
+	s.userSearcher = userS
+	s.assistantSearcher = nil
+
+	sr, backend, err := s.selectSearcher(SearchOptions{ActionToken: "TK"})
+	require.NoError(t, err)
+	assert.Equal(t, SearchBackendUser, backend)
+	gotMock, ok := sr.(*mockSearcher)
+	require.True(t, ok)
+	assert.Same(t, userS, gotMock)
+}
+
+func TestSlackSearchService_SelectSearcherWithNothingErrors(t *testing.T) {
+	s := newTestService(defaultConfig())
+	s.userSearcher = nil
+	s.assistantSearcher = nil
+
+	_, _, err := s.selectSearcher(SearchOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SLACK_USER_TOKEN")
+}
+
+func TestSlackSearchService_SearchDispatchesToAssistant(t *testing.T) {
+	cfg := defaultConfig()
+	service := newTestService(cfg)
+
+	qg := &mockQueryGenerator{}
+	userS := &mockSearcher{}
+	asstS := &mockSearcher{}
+	suff := &mockSufficiencyChecker{}
+
+	service.queryGenerator = qg
+	service.userSearcher = userS
+	service.assistantSearcher = asstS
+	service.contextRetriever = &mockContextRetriever{}
+	service.sufficiencyChecker = suff
+
+	qg.On("GenerateQueries", mock.Anything, mock.AnythingOfType("*slacksearch.QueryGenerationRequest")).
+		Return(&QueryGenerationResponse{Queries: []string{"q1"}}, nil).Once()
+
+	// assistantSearcher must be called and receive ActionToken + ContextChannelID.
+	asstS.On("SearchWithRetry", mock.Anything, mock.MatchedBy(func(req *SearchRequest) bool {
+		return req.ActionToken == "TK_FROM_EVENT" && req.ContextChannelID == "C_ORIGIN"
+	}), cfg.MaxRetries).Return(&SearchResponse{
+		Messages:   []slack.Message{slackMsg("1700000000.000100", "hit")},
+		TotalCount: 1,
+	}, nil).Once()
+
+	suff.On("Check", mock.Anything, mock.AnythingOfType("*slacksearch.SufficiencyRequest")).
+		Return(&SufficiencyResponse{IsSufficient: true, MissingInfo: nil, Confidence: 0.9}, nil).Once()
+
+	result, err := service.Search(context.Background(), "find x", nil, SearchOptions{
+		ActionToken: "TK_FROM_EVENT",
+		ChannelID:   "C_ORIGIN",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.EnrichedMessages, 1)
+
+	asstS.AssertExpectations(t)
+	// user searcher must NOT be called when action_token is set.
+	userS.AssertNotCalled(t, "SearchWithRetry", mock.Anything, mock.Anything, mock.Anything)
+	qg.AssertExpectations(t)
+	suff.AssertExpectations(t)
 }

--- a/internal/pkg/slacksearch/service_test.go
+++ b/internal/pkg/slacksearch/service_test.go
@@ -306,7 +306,7 @@ func contextBackground() context.Context {
 
 // --- selectSearcher / dispatch tests ---
 
-func TestSlackSearchService_SelectSearcherUsesAssistantWhenActionToken(t *testing.T) {
+func TestSlackSearchService_SelectSearcherPrefersUserWhenAvailable(t *testing.T) {
 	s := newTestService(defaultConfig())
 	userS := &mockSearcher{}
 	asstS := &mockSearcher{}
@@ -315,11 +315,11 @@ func TestSlackSearchService_SelectSearcherUsesAssistantWhenActionToken(t *testin
 
 	sr, backend, err := s.selectSearcher(SearchOptions{ActionToken: "TK"})
 	require.NoError(t, err)
-	assert.Equal(t, SearchBackendAssistant, backend)
+	assert.Equal(t, SearchBackendUser, backend)
 	// Compare interface identity by type assertion to *mockSearcher.
 	gotMock, ok := sr.(*mockSearcher)
 	require.True(t, ok)
-	assert.Same(t, asstS, gotMock)
+	assert.Same(t, userS, gotMock)
 }
 
 func TestSlackSearchService_SelectSearcherFallsBackToUserWithoutActionToken(t *testing.T) {
@@ -351,6 +351,20 @@ func TestSlackSearchService_SelectSearcherActionTokenButNoAssistantUsesUser(t *t
 	assert.Same(t, userS, gotMock)
 }
 
+func TestSlackSearchService_SelectSearcherUsesAssistantWhenUserUnavailable(t *testing.T) {
+	s := newTestService(defaultConfig())
+	asstS := &mockSearcher{}
+	s.userSearcher = nil
+	s.assistantSearcher = asstS
+
+	sr, backend, err := s.selectSearcher(SearchOptions{ActionToken: "TK"})
+	require.NoError(t, err)
+	assert.Equal(t, SearchBackendAssistant, backend)
+	gotMock, ok := sr.(*mockSearcher)
+	require.True(t, ok)
+	assert.Same(t, asstS, gotMock)
+}
+
 func TestSlackSearchService_SelectSearcherWithNothingErrors(t *testing.T) {
 	s := newTestService(defaultConfig())
 	s.userSearcher = nil
@@ -361,32 +375,49 @@ func TestSlackSearchService_SelectSearcherWithNothingErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "SLACK_USER_TOKEN")
 }
 
-func TestSlackSearchService_SearchDispatchesToAssistant(t *testing.T) {
+func TestSlackSearchService_FallbackEnrichedPreservesPermalink(t *testing.T) {
+	service := newTestService(defaultConfig())
+	msg := slack.Message{Msg: slack.Msg{
+		Channel:   "C1",
+		Timestamp: "1700000000.000100",
+		Text:      "hit",
+		Permalink: "https://example.slack.com/archives/C1/p1700000000000100",
+	}}
+
+	enriched := service.fallbackEnriched([]slack.Message{msg})
+	require.Len(t, enriched, 1)
+	assert.Equal(t, msg.Permalink, enriched[0].Permalink)
+}
+
+func TestSlackSearchService_SearchPrefersUserBackendWhenActionTokenAndUserSearcher(t *testing.T) {
 	cfg := defaultConfig()
 	service := newTestService(cfg)
 
 	qg := &mockQueryGenerator{}
 	userS := &mockSearcher{}
 	asstS := &mockSearcher{}
+	contextRetriever := &mockContextRetriever{}
 	suff := &mockSufficiencyChecker{}
 
 	service.queryGenerator = qg
 	service.userSearcher = userS
 	service.assistantSearcher = asstS
-	service.contextRetriever = &mockContextRetriever{}
+	service.contextRetriever = contextRetriever
 	service.sufficiencyChecker = suff
+
+	msg := slackMsg("1700000000.000100", "user-token hit")
+	enriched := []EnrichedMessage{{OriginalMessage: msg, Permalink: "https://example.com/user-hit"}}
 
 	qg.On("GenerateQueries", mock.Anything, mock.AnythingOfType("*slacksearch.QueryGenerationRequest")).
 		Return(&QueryGenerationResponse{Queries: []string{"q1"}}, nil).Once()
-
-	// assistantSearcher must be called and receive ActionToken + ContextChannelID.
-	asstS.On("SearchWithRetry", mock.Anything, mock.MatchedBy(func(req *SearchRequest) bool {
-		return req.ActionToken == "TK_FROM_EVENT" && req.ContextChannelID == "C_ORIGIN"
+	userS.On("SearchWithRetry", mock.Anything, mock.MatchedBy(func(req *SearchRequest) bool {
+		return req.ActionToken == "TK_FROM_EVENT" && req.Query == "q1"
 	}), cfg.MaxRetries).Return(&SearchResponse{
-		Messages:   []slack.Message{slackMsg("1700000000.000100", "hit")},
+		Messages:   []slack.Message{msg},
 		TotalCount: 1,
 	}, nil).Once()
-
+	contextRetriever.On("RetrieveContext", mock.Anything, mock.AnythingOfType("*slacksearch.ContextRequest")).
+		Return(&ContextResponse{EnrichedMessages: enriched, TotalRetrieved: 1}, nil).Once()
 	suff.On("Check", mock.Anything, mock.AnythingOfType("*slacksearch.SufficiencyRequest")).
 		Return(&SufficiencyResponse{IsSufficient: true, MissingInfo: nil, Confidence: 0.9}, nil).Once()
 
@@ -397,10 +428,82 @@ func TestSlackSearchService_SearchDispatchesToAssistant(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.EnrichedMessages, 1)
+	assert.Equal(t, "https://example.com/user-hit", result.Sources["C1#1700000000.000100"])
+
+	userS.AssertExpectations(t)
+	asstS.AssertNotCalled(t, "SearchWithRetry", mock.Anything, mock.Anything, mock.Anything)
+	contextRetriever.AssertExpectations(t)
+	qg.AssertExpectations(t)
+	suff.AssertExpectations(t)
+}
+
+func TestSlackSearchService_SearchDispatchesToAssistantWhenUserUnavailable(t *testing.T) {
+	cfg := defaultConfig()
+	service := newTestService(cfg)
+
+	qg := &mockQueryGenerator{}
+	asstS := &mockSearcher{}
+	contextRetriever := &mockContextRetriever{}
+	suff := &mockSufficiencyChecker{}
+
+	service.queryGenerator = qg
+	service.userSearcher = nil
+	service.assistantSearcher = asstS
+	service.contextRetriever = contextRetriever
+	service.sufficiencyChecker = suff
+
+	msg := slack.Message{Msg: slack.Msg{
+		Channel:   "C1",
+		User:      "U1",
+		Timestamp: "1700000000.000100",
+		Text:      "hit",
+		Permalink: "https://example.slack.com/archives/C1/p1700000000000100",
+	}}
+	prev := slackMsg("1700000000.000000", "before context")
+	next := slackMsg("1700000000.000200", "after context")
+
+	qg.On("GenerateQueries", mock.Anything, mock.AnythingOfType("*slacksearch.QueryGenerationRequest")).
+		Return(&QueryGenerationResponse{Queries: []string{"q1"}}, nil).Once()
+
+	// assistantSearcher must be called and receive ActionToken + ContextChannelID only when userSearcher is unavailable.
+	asstS.On("SearchWithRetry", mock.Anything, mock.MatchedBy(func(req *SearchRequest) bool {
+		return req.ActionToken == "TK_FROM_EVENT" && req.ContextChannelID == "C_ORIGIN"
+	}), cfg.MaxRetries).Return(&SearchResponse{
+		Messages: []slack.Message{msg},
+		EnrichedMessages: []EnrichedMessage{
+			{
+				OriginalMessage:  msg,
+				PreviousMessages: []slack.Message{prev},
+				NextMessages:     []slack.Message{next},
+				Permalink:        msg.Permalink,
+			},
+		},
+		TotalCount: 1,
+	}, nil).Once()
+
+	suff.On("Check", mock.Anything, mock.MatchedBy(func(req *SufficiencyRequest) bool {
+		return len(req.Messages) == 1 &&
+			len(req.Messages[0].PreviousMessages) == 1 &&
+			req.Messages[0].PreviousMessages[0].Text == "before context" &&
+			len(req.Messages[0].NextMessages) == 1 &&
+			req.Messages[0].NextMessages[0].Text == "after context"
+	})).
+		Return(&SufficiencyResponse{IsSufficient: true, MissingInfo: nil, Confidence: 0.9}, nil).Once()
+
+	result, err := service.Search(context.Background(), "find x", nil, SearchOptions{
+		ActionToken: "TK_FROM_EVENT",
+		ChannelID:   "C_ORIGIN",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.EnrichedMessages, 1)
+	assert.Equal(t, msg.Permalink, result.EnrichedMessages[0].Permalink)
+	assert.Equal(t, msg.Permalink, result.Sources["C1#1700000000.000100"])
+	assert.Equal(t, "before context", result.EnrichedMessages[0].PreviousMessages[0].Text)
+	assert.Equal(t, "after context", result.EnrichedMessages[0].NextMessages[0].Text)
 
 	asstS.AssertExpectations(t)
-	// user searcher must NOT be called when action_token is set.
-	userS.AssertNotCalled(t, "SearchWithRetry", mock.Anything, mock.Anything, mock.Anything)
+	contextRetriever.AssertNotCalled(t, "RetrieveContext", mock.Anything, mock.Anything)
 	qg.AssertExpectations(t)
 	suff.AssertExpectations(t)
 }

--- a/internal/pkg/slacksearch/slack_result.go
+++ b/internal/pkg/slacksearch/slack_result.go
@@ -34,6 +34,20 @@ func (r *SlackConversationResult) ForPrompt() string {
 			user,
 			strings.TrimSpace(msg.Text),
 		)
+		for _, prev := range msg.Previous {
+			prevUser := prev.Username
+			if prevUser == "" {
+				prevUser = prev.User
+			}
+			if prevUser == "" {
+				prevUser = "unknown"
+			}
+			fmt.Fprintf(&sb, "    • Previous at %s by %s: %s\n",
+				prev.Timestamp,
+				prevUser,
+				strings.TrimSpace(prev.Text),
+			)
+		}
 		for _, reply := range msg.Thread {
 			replyUser := reply.Username
 			if replyUser == "" {
@@ -48,6 +62,20 @@ func (r *SlackConversationResult) ForPrompt() string {
 				strings.TrimSpace(reply.Text),
 			)
 		}
+		for _, next := range msg.Next {
+			nextUser := next.Username
+			if nextUser == "" {
+				nextUser = next.User
+			}
+			if nextUser == "" {
+				nextUser = "unknown"
+			}
+			fmt.Fprintf(&sb, "    • Next at %s by %s: %s\n",
+				next.Timestamp,
+				nextUser,
+				strings.TrimSpace(next.Text),
+			)
+		}
 	}
 	return sb.String()
 }
@@ -60,6 +88,8 @@ type SlackConversationMessage struct {
 	Text      string
 	Permalink string
 	Thread    []SlackThreadMessage
+	Previous  []SlackThreadMessage
+	Next      []SlackThreadMessage
 }
 
 type SlackThreadMessage struct {

--- a/internal/pkg/slacksearch/types.go
+++ b/internal/pkg/slacksearch/types.go
@@ -32,6 +32,14 @@ type SearchOptions struct {
 	ChannelID       string
 	ThreadTimestamp string
 	UserID          string
+	// ActionToken is the short-lived token surfaced by Slack on app_mention /
+	// message events under `event.assistant_thread.action_token`. When set, the
+	// Slack search service uses the Real-time Search API
+	// (`assistant.search.context`) on the bot token, which lets a bot search
+	// public channels it has not been invited to. When empty, the service
+	// falls back to the legacy `search.messages` flow that requires
+	// SLACK_USER_TOKEN.
+	ActionToken string
 }
 
 // EnrichedMessage combines a Slack message with additional contextual data.
@@ -92,8 +100,12 @@ func (c *SlackSearchConfig) Validate() error {
 		return nil
 	}
 
-	if strings.TrimSpace(c.UserToken) == "" {
-		return fmt.Errorf("user_token must be provided when Slack search is enabled")
+	// At least one of BotToken or UserToken must be available when Slack
+	// search is enabled. The UserToken (xoxp) backs legacy search.messages;
+	// the BotToken (xoxb) backs assistant.search.context only when a Slack
+	// event action_token is provided per request.
+	if strings.TrimSpace(c.BotToken) == "" && strings.TrimSpace(c.UserToken) == "" {
+		return fmt.Errorf("either bot_token or user_token must be provided when Slack search is enabled")
 	}
 
 	if c.MaxResults <= 0 || c.MaxResults > 100 {

--- a/internal/pkg/slacksearch/types.go
+++ b/internal/pkg/slacksearch/types.go
@@ -33,12 +33,9 @@ type SearchOptions struct {
 	ThreadTimestamp string
 	UserID          string
 	// ActionToken is the short-lived token surfaced by Slack on app_mention /
-	// message events under `event.assistant_thread.action_token`. When set, the
-	// Slack search service uses the Real-time Search API
-	// (`assistant.search.context`) on the bot token, which lets a bot search
-	// public channels it has not been invited to. When empty, the service
-	// falls back to the legacy `search.messages` flow that requires
-	// SLACK_USER_TOKEN.
+	// message events under `event.assistant_thread.action_token`. It enables the
+	// Real-time Search API (`assistant.search.context`) on the bot token only
+	// when the legacy SLACK_USER_TOKEN search backend is unavailable.
 	ActionToken string
 }
 
@@ -79,11 +76,25 @@ func (r *SlackSearchResult) ForPrompt() string {
 			FormatSlackUser(orig.User, orig.Username),
 			strings.TrimSpace(orig.Text),
 		)
+		for _, prev := range msg.PreviousMessages {
+			fmt.Fprintf(&sb, "    • Previous at %s by %s: %s\n",
+				FormatSlackTimestamp(prev.Timestamp),
+				FormatSlackUser(prev.User, prev.Username),
+				strings.TrimSpace(prev.Text),
+			)
+		}
 		for _, reply := range msg.ThreadMessages {
 			fmt.Fprintf(&sb, "    • Reply at %s by %s: %s\n",
 				FormatSlackTimestamp(reply.Timestamp),
 				FormatSlackUser(reply.User, reply.Username),
 				strings.TrimSpace(reply.Text),
+			)
+		}
+		for _, next := range msg.NextMessages {
+			fmt.Fprintf(&sb, "    • Next at %s by %s: %s\n",
+				FormatSlackTimestamp(next.Timestamp),
+				FormatSlackUser(next.User, next.Username),
+				strings.TrimSpace(next.Text),
 			)
 		}
 	}

--- a/internal/query/query_command.go
+++ b/internal/query/query_command.go
@@ -574,8 +574,13 @@ func defaultSlackSearch(
 	if slackCfg.BotToken == "" {
 		return nil, fmt.Errorf("slack bot token (SLACK_BOT_TOKEN) not configured")
 	}
+	// The CLI/query path has no Slack event → no action_token, so the
+	// assistant.search.context backend is unavailable. We must have a user
+	// token (xoxp) to talk to legacy search.messages.
 	if strings.TrimSpace(cfg.SlackUserToken) == "" {
-		return nil, fmt.Errorf("slack user token (SLACK_USER_TOKEN) not configured")
+		return nil, fmt.Errorf(
+			"slack search from the query CLI requires SLACK_USER_TOKEN " +
+				"(assistant.search.context needs a Slack event action_token, which the CLI cannot provide)")
 	}
 
 	slackClient := slack.New(slackCfg.BotToken)
@@ -593,7 +598,7 @@ func defaultSlackSearch(
 	}
 
 	sanitized := slacksearch.SanitizeSlackChannels(channels)
-	return slackService.Search(ctx, userQuery, sanitized)
+	return slackService.Search(ctx, userQuery, sanitized, slacksearch.SearchOptions{})
 }
 
 func defaultSlackOnlySearch(
@@ -611,8 +616,12 @@ func defaultSlackOnlySearch(
 	if slackCfg.BotToken == "" {
 		return nil, fmt.Errorf("slack bot token (SLACK_BOT_TOKEN) not configured")
 	}
+	// Slack-only mode is invoked from the CLI; same constraint as above —
+	// assistant.search.context needs an action_token we cannot obtain here.
 	if strings.TrimSpace(cfg.SlackUserToken) == "" {
-		return nil, fmt.Errorf("slack user token (SLACK_USER_TOKEN) not configured")
+		return nil, fmt.Errorf(
+			"--only-slack from the query CLI requires SLACK_USER_TOKEN " +
+				"(assistant.search.context needs a Slack event action_token, which the CLI cannot provide)")
 	}
 
 	slackClient := slack.New(slackCfg.BotToken)
@@ -634,7 +643,7 @@ func defaultSlackOnlySearch(
 	}
 
 	sanitized := slacksearch.SanitizeSlackChannels(channels)
-	return slackService.Search(ctx, userQuery, sanitized)
+	return slackService.Search(ctx, userQuery, sanitized, slacksearch.SearchOptions{})
 }
 
 func defaultFetchSlackURLContext(

--- a/internal/query/search/hybrid_service.go
+++ b/internal/query/search/hybrid_service.go
@@ -471,7 +471,9 @@ func (s *HybridSearchService) executeSlackSearch(ctx context.Context, request *S
 	defer cancel()
 
 	channels := slacksearch.SanitizeSlackChannels(request.SlackChannels)
-	return s.slackService.Search(slackCtx, request.Query, channels)
+	// CLI/MCP callers have no Slack event action_token, so the slacksearch
+	// service falls back to the user-token (search.messages) backend.
+	return s.slackService.Search(slackCtx, request.Query, channels, slacksearch.SearchOptions{})
 }
 
 func queryMentionsSlack(query string) bool {

--- a/internal/slackbot/action_token.go
+++ b/internal/slackbot/action_token.go
@@ -1,0 +1,30 @@
+package slackbot
+
+import "context"
+
+// actionTokenContextKey is the unexported context key used to propagate the
+// Slack Real-time Search API `action_token` from the event-receive layer
+// (Socket Mode) down to the search adapter, without having to widen the
+// Processor.ProcessMessage signature.
+type actionTokenContextKey struct{}
+
+// ContextWithActionToken stores a Slack `action_token` on ctx. The token is
+// surfaced by `app_mention` / `message` event payloads under
+// `event.assistant_thread.action_token` and is required to call
+// `assistant.search.context` with a bot token. An empty token is a no-op.
+func ContextWithActionToken(ctx context.Context, token string) context.Context {
+	if token == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, actionTokenContextKey{}, token)
+}
+
+// ActionTokenFromContext returns the action_token stored on ctx, or "" if
+// none is present.
+func ActionTokenFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	token, _ := ctx.Value(actionTokenContextKey{}).(string)
+	return token
+}

--- a/internal/slackbot/bot.go
+++ b/internal/slackbot/bot.go
@@ -122,7 +122,7 @@ func (b *Bot) Start(ctx context.Context) error {
 }
 
 func (b *Bot) handleEvent(ctx context.Context, ev slack.RTMEvent) {
-	fmt.Printf("handleEvent: %+v\n", ev)
+	b.logger.Printf("handleEvent type=%s", ev.Type)
 
 	switch data := ev.Data.(type) {
 	case *slack.MessageEvent:

--- a/internal/slackbot/command.go
+++ b/internal/slackbot/command.go
@@ -2,6 +2,7 @@ package slackbot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -16,6 +17,11 @@ import (
 	"github.com/ca-srg/ragent/internal/pkg/metrics"
 	"github.com/ca-srg/ragent/internal/pkg/observability"
 )
+
+const slackSearchTokenConfigError = "RTM path requires SLACK_USER_TOKEN; otherwise enable Socket Mode with " +
+	"SLACK_APP_TOKEN for assistant.search.context"
+
+var errSlackSearchTokenConfig = errors.New(slackSearchTokenConfigError)
 
 // SlackBotOptions holds the command-line options for the slack-bot command.
 type SlackBotOptions struct {
@@ -58,15 +64,16 @@ func RunSlackBot(ctx context.Context, opts SlackBotOptions) error {
 	if err != nil {
 		return fmt.Errorf("failed to load slack config: %w", err)
 	}
-	if strings.TrimSpace(cfg.SlackUserToken) == "" {
-		logger.Printf("SLACK_USER_TOKEN is not configured; slack-bot Slack search requires event action_token and uses assistant.search.context")
+	if err := validateSlackSearchTokenConfig(cfg.SlackUserToken, scfg); err != nil {
+		return err
 	}
+	socketModeAppToken := slackSocketModeAppToken(scfg)
 
 	// Slack client
 	// For Socket Mode, the app-level token must be supplied to the client options
 	var clientOpts []slack.Option
-	if scfg.SocketMode && scfg.AppToken != "" {
-		clientOpts = append(clientOpts, slack.OptionAppLevelToken(scfg.AppToken))
+	if socketModeAppToken != "" {
+		clientOpts = append(clientOpts, slack.OptionAppLevelToken(socketModeAppToken))
 	}
 	client := slack.New(scfg.BotToken, clientOpts...)
 
@@ -146,8 +153,8 @@ func RunSlackBot(ctx context.Context, opts SlackBotOptions) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	if scfg.SocketMode && scfg.AppToken != "" {
-		sbot, err := NewSocketBot(client, scfg.AppToken, processor, logger)
+	if socketModeAppToken != "" {
+		sbot, err := NewSocketBot(client, socketModeAppToken, processor, logger)
 		if err != nil {
 			return err
 		}
@@ -176,4 +183,18 @@ func RunSlackBot(ctx context.Context, opts SlackBotOptions) error {
 	// Run
 	logger.Printf("Starting Slack Bot (RTM) (max_results=%d)...", scfg.MaxResults)
 	return bot.Start(ctx)
+}
+
+func validateSlackSearchTokenConfig(userToken string, scfg *appcfg.SlackConfig) error {
+	if strings.TrimSpace(userToken) != "" || slackSocketModeAppToken(scfg) != "" {
+		return nil
+	}
+	return errSlackSearchTokenConfig
+}
+
+func slackSocketModeAppToken(scfg *appcfg.SlackConfig) string {
+	if scfg == nil || !scfg.SocketMode {
+		return ""
+	}
+	return strings.TrimSpace(scfg.AppToken)
 }

--- a/internal/slackbot/command.go
+++ b/internal/slackbot/command.go
@@ -59,7 +59,7 @@ func RunSlackBot(ctx context.Context, opts SlackBotOptions) error {
 		return fmt.Errorf("failed to load slack config: %w", err)
 	}
 	if strings.TrimSpace(cfg.SlackUserToken) == "" {
-		return fmt.Errorf("slack user token (SLACK_USER_TOKEN) not configured; enable Slack search requires user token with search scopes")
+		logger.Printf("SLACK_USER_TOKEN is not configured; slack-bot Slack search requires event action_token and uses assistant.search.context")
 	}
 
 	// Slack client

--- a/internal/slackbot/command_test.go
+++ b/internal/slackbot/command_test.go
@@ -1,0 +1,64 @@
+package slackbot
+
+import (
+	"testing"
+
+	appcfg "github.com/ca-srg/ragent/internal/pkg/config"
+)
+
+func TestValidateSlackSearchTokenConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		userToken string
+		scfg      *appcfg.SlackConfig
+		wantErr   bool
+	}{
+		{
+			name:      "bot token only without socket mode returns error",
+			userToken: "",
+			scfg:      &appcfg.SlackConfig{SocketMode: false, AppToken: ""},
+			wantErr:   true,
+		},
+		{
+			name:      "bot token only with socket mode and app token succeeds",
+			userToken: "",
+			scfg:      &appcfg.SlackConfig{SocketMode: true, AppToken: "xapp-test-token"},
+			wantErr:   false,
+		},
+		{
+			name:      "bot token only with socket mode but blank app token returns error",
+			userToken: "",
+			scfg:      &appcfg.SlackConfig{SocketMode: true, AppToken: "   "},
+			wantErr:   true,
+		},
+		{
+			name:      "user token with RTM succeeds",
+			userToken: "xoxp-test-token",
+			scfg:      &appcfg.SlackConfig{SocketMode: false, AppToken: ""},
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateSlackSearchTokenConfig(tt.userToken, tt.scfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected validation error")
+				}
+				if err.Error() != slackSearchTokenConfigError {
+					t.Fatalf("unexpected error message: %q", err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no validation error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/slackbot/conv_searcher.go
+++ b/internal/slackbot/conv_searcher.go
@@ -112,6 +112,16 @@ func ConvertSlackSearchResult(src *slacksearch.SlackSearchResult) *SlackConversa
 			Text:      msg.OriginalMessage.Text,
 			Permalink: msg.Permalink,
 			Thread:    make([]SlackThreadMessage, 0, len(msg.ThreadMessages)),
+			Previous:  make([]SlackThreadMessage, 0, len(msg.PreviousMessages)),
+			Next:      make([]SlackThreadMessage, 0, len(msg.NextMessages)),
+		}
+		for _, prev := range msg.PreviousMessages {
+			conv.Previous = append(conv.Previous, SlackThreadMessage{
+				Timestamp: prev.Timestamp,
+				User:      prev.User,
+				Username:  prev.Username,
+				Text:      prev.Text,
+			})
 		}
 		for _, reply := range msg.ThreadMessages {
 			conv.Thread = append(conv.Thread, SlackThreadMessage{
@@ -119,6 +129,14 @@ func ConvertSlackSearchResult(src *slacksearch.SlackSearchResult) *SlackConversa
 				User:      reply.User,
 				Username:  reply.Username,
 				Text:      reply.Text,
+			})
+		}
+		for _, next := range msg.NextMessages {
+			conv.Next = append(conv.Next, SlackThreadMessage{
+				Timestamp: next.Timestamp,
+				User:      next.User,
+				Username:  next.Username,
+				Text:      next.Text,
 			})
 		}
 		dst.Messages = append(dst.Messages, conv)

--- a/internal/slackbot/conv_searcher.go
+++ b/internal/slackbot/conv_searcher.go
@@ -14,7 +14,12 @@ import (
 )
 
 type SlackConversationService interface {
-	Search(ctx context.Context, query string, channels []string) (*slacksearch.SlackSearchResult, error)
+	Search(
+		ctx context.Context,
+		query string,
+		channels []string,
+		opts slacksearch.SearchOptions,
+	) (*slacksearch.SlackSearchResult, error)
 }
 
 type botSlackSearcher struct {
@@ -54,7 +59,10 @@ func (b *botSlackSearcher) SearchConversations(ctx context.Context, query string
 		return nil, nil
 	}
 	channels := b.channelFilter(opts.ChannelID)
-	result, err := b.service.Search(ctx, query, channels)
+	// Propagate the full SearchOptions (most importantly opts.ActionToken
+	// surfaced from the originating Slack event) to the slacksearch service
+	// so it can switch to assistant.search.context when available.
+	result, err := b.service.Search(ctx, query, channels, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/slackbot/processor.go
+++ b/internal/slackbot/processor.go
@@ -136,11 +136,15 @@ func (p *Processor) ProcessMessage(ctx context.Context, botUserID string, msg *s
 		span.SetAttributes(attribute.String("slack.query.enhanced", truncateForAttribute(searchQuery)))
 	}
 
-	// Perform search
+	// Perform search. ActionToken is propagated from the inbound Slack event
+	// (set by the Socket Mode handler via ContextWithActionToken). When
+	// present, the slacksearch service can switch to assistant.search.context
+	// on the bot token to reach public channels the bot has not joined.
 	result := p.search.Search(ctx, searchQuery, SearchOptions{
 		ChannelID:       msg.Channel,
 		ThreadTimestamp: msg.ThreadTimestamp,
 		UserID:          msg.User,
+		ActionToken:     ActionTokenFromContext(ctx),
 	})
 	if result != nil {
 		span.SetAttributes(

--- a/internal/slackbot/socketmode.go
+++ b/internal/slackbot/socketmode.go
@@ -2,6 +2,7 @@ package slackbot
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -121,14 +122,31 @@ func (b *SocketBot) handleEvent(ctx context.Context, ev socketmode.Event) {
 		// observed in time, when the websocket reconnects, or when multiple
 		// event subscriptions overlap. Process each event_id only once.
 		var eventID string
+		var rawInnerEvent json.RawMessage
 		if cb, ok := payload.Data.(*slackevents.EventsAPICallbackEvent); ok && cb != nil {
 			eventID = cb.EventID
+			if cb.InnerEvent != nil {
+				rawInnerEvent = *cb.InnerEvent
+			}
 		}
 		if eventID != "" {
 			if b.dedup.markSeen(eventID) {
 				b.logger.Printf("event=events_api status=duplicate event_id=%s", eventID)
 				return
 			}
+		}
+
+		// Probe the raw inner event JSON for action_token because the public
+		// docs and JS examples (https://docs.slack.dev/ai/developing-agents)
+		// surface `event.action_token` at the top level, while slack-go
+		// v0.23.1 only models the nested `event.assistant_thread.action_token`
+		// path. We log both so the operator can see exactly which shape Slack
+		// is sending in their workspace, and fall back to the top-level value
+		// when slack-go fails to populate AssistantThread.
+		probeToken, probeHasNested, probeHasTop := probeActionToken(rawInnerEvent)
+		if len(rawInnerEvent) > 0 {
+			b.logger.Printf("event=events_api action_token_probe top_level=%t assistant_thread=%t",
+				probeHasTop, probeHasNested)
 		}
 
 		inner := payload.InnerEvent
@@ -156,7 +174,21 @@ func (b *SocketBot) handleEvent(ctx context.Context, ev socketmode.Event) {
 					BotID:           data.BotID,
 				},
 			}
-			b.processMessage(ctx, msg)
+			// Surface the short-lived action_token (Real-time Search API) so
+			// the search adapter can use assistant.search.context on a bot
+			// token, which lets the bot reach public channels it is not in.
+			msgCtx := ctx
+			token := ""
+			if data.AssistantThread != nil && data.AssistantThread.ActionToken != "" {
+				token = data.AssistantThread.ActionToken
+			}
+			if token == "" {
+				token = probeToken
+			}
+			if token != "" {
+				msgCtx = ContextWithActionToken(msgCtx, token)
+			}
+			b.processMessage(msgCtx, msg)
 		case *slackevents.MessageEvent:
 			// Only process plain user messages.
 			if data.SubType != "" { // ignore bot_message, message_changed, etc.
@@ -185,13 +217,59 @@ func (b *SocketBot) handleEvent(ctx context.Context, ev socketmode.Event) {
 					BotID:           data.BotID,
 				},
 			}
-			b.processMessage(ctx, msg)
+			msgCtx := ctx
+			token := ""
+			if data.AssistantThread != nil && data.AssistantThread.ActionToken != "" {
+				token = data.AssistantThread.ActionToken
+			}
+			if token == "" {
+				token = probeToken
+			}
+			if token != "" {
+				msgCtx = ContextWithActionToken(msgCtx, token)
+			}
+			b.processMessage(msgCtx, msg)
 		default:
 			// ignore other events
 		}
 	default:
 		// ignore
 	}
+}
+
+// probeActionToken extracts the Slack Real-time Search API action_token from
+// the raw inner event JSON. Slack publishes it either at top-level
+// (`event.action_token`, used by some official examples) or nested under
+// `event.assistant_thread.action_token` (the shape slack-go models on the
+// AppMentionEvent / MessageEvent structs). Both shapes are accepted so we
+// can hand the token to assistant.search.context regardless of which form
+// the workspace happens to deliver.
+func probeActionToken(raw json.RawMessage) (token string, hasNested, hasTop bool) {
+	if len(raw) == 0 {
+		return "", false, false
+	}
+	var probe struct {
+		ActionToken     string `json:"action_token"`
+		AssistantThread *struct {
+			ActionToken string `json:"action_token"`
+		} `json:"assistant_thread"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return "", false, false
+	}
+	if probe.AssistantThread != nil {
+		hasNested = true
+		if strings.TrimSpace(probe.AssistantThread.ActionToken) != "" {
+			token = probe.AssistantThread.ActionToken
+		}
+	}
+	if strings.TrimSpace(probe.ActionToken) != "" {
+		hasTop = true
+		if token == "" {
+			token = probe.ActionToken
+		}
+	}
+	return token, hasNested, hasTop
 }
 
 // isBotOrigin reports whether an inbound event was authored by a bot

--- a/internal/slackbot/socketmode.go
+++ b/internal/slackbot/socketmode.go
@@ -87,8 +87,8 @@ func (b *SocketBot) Start(ctx context.Context) error {
 }
 
 func (b *SocketBot) handleEvent(ctx context.Context, ev socketmode.Event) {
-	// lightweight diagnostics similar to RTM path
-	fmt.Printf("handleEvent: {Type:%s Data:%v}\n", ev.Type, ev.Data)
+	// Log only the event type; ev.Data may contain short-lived action_token values.
+	b.logger.Printf("handleEvent type=%s", ev.Type)
 
 	switch ev.Type {
 	case socketmode.EventTypeConnecting:

--- a/internal/slackbot/socketmode.go
+++ b/internal/slackbot/socketmode.go
@@ -104,7 +104,9 @@ func (b *SocketBot) handleEvent(ctx context.Context, ev socketmode.Event) {
 	case socketmode.EventTypeEventsAPI:
 		// Ack first to avoid Slack retries.
 		if ev.Request != nil {
-			b.sm.Ack(*ev.Request)
+			if err := b.sm.Ack(*ev.Request); err != nil {
+				b.logger.Printf("event=events_api ack_error=%v envelope_id=%s", err, ev.Request.EnvelopeID)
+			}
 			if ev.Request.RetryAttempt > 0 {
 				b.logger.Printf("event=events_api retry_attempt=%d retry_reason=%s envelope_id=%s",
 					ev.Request.RetryAttempt, ev.Request.RetryReason, ev.Request.EnvelopeID)

--- a/internal/slackbot/socketmode_test.go
+++ b/internal/slackbot/socketmode_test.go
@@ -1,0 +1,69 @@
+package slackbot
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/slack-go/slack/socketmode"
+)
+
+func TestSocketBotHandleEventDoesNotLogActionToken(t *testing.T) {
+	const actionToken = "test-action-token-redacted"
+
+	var logs bytes.Buffer
+	bot := &SocketBot{logger: log.New(&logs, "", 0)}
+	event := socketmode.Event{
+		Type: socketmode.EventTypeConnecting,
+		Data: map[string]string{
+			"action_token": actionToken,
+		},
+	}
+
+	stdout := captureStdout(t, func() {
+		bot.handleEvent(context.Background(), event)
+	})
+
+	if strings.Contains(logs.String(), actionToken) {
+		t.Fatalf("action token leaked to logger: %q", logs.String())
+	}
+	if strings.Contains(stdout, actionToken) {
+		t.Fatalf("action token leaked to stdout: %q", stdout)
+	}
+	if !strings.Contains(logs.String(), "handleEvent type=") {
+		t.Fatalf("expected type-only handleEvent log, got %q", logs.String())
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+	defer func() {
+		os.Stdout = original
+	}()
+
+	os.Stdout = writer
+	fn()
+	os.Stdout = original
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("failed to close stdout writer: %v", err)
+	}
+	out, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("failed to read stdout: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("failed to close stdout reader: %v", err)
+	}
+	return string(out)
+}

--- a/terraform/README_ja.md
+++ b/terraform/README_ja.md
@@ -425,7 +425,7 @@ RAGent は起動時に `SECRET_MANAGER_SECRET_ID` が設定されていると、
 | `OPENSEARCH_ENDPOINT` | OpenSearch エンドポイント URL | 全コマンドで必須 |
 | `OPENSEARCH_INDEX` | OpenSearch インデックス名 | 全コマンドで必須 |
 | `SLACK_BOT_TOKEN` | Slack Bot トークン (`xoxb-`) | `slack-bot` コマンド |
-| `SLACK_USER_TOKEN` | Slack User トークン (`xoxp-`) | Slack 検索機能（`search:read` スコープ必須） |
+| `SLACK_USER_TOKEN` | Slack User トークン (`xoxp-`) | 任意。設定時は `search:read` スコープを付与した user token で `search.messages` を呼び出します。未設定の場合は slack-bot のイベント由来 `action_token` がある経路のみ Bot Token (`xoxb-`) で `assistant.search.context` を呼び出せます |
 | `SLACK_APP_TOKEN` | Slack App-level トークン (`xapp-`) | Socket Mode 利用時 |
 | `OIDC_ISSUER` | OIDC プロバイダー URL | MCP Server OIDC 認証時 |
 | `OIDC_CLIENT_ID` | OIDC クライアント ID | MCP Server OIDC 認証時 |


### PR DESCRIPTION
# Pull Request

## Summary
Adds Slack Real-time Search (`assistant.search.context`) support for slack-bot requests by propagating per-event `action_token`s, while keeping CLI/MCP Slack search on the legacy user-token `search.messages` path.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Changes Made
- Added an `AssistantSearcher` backend for Slack `assistant.search.context` and dispatch logic based on `SearchOptions.ActionToken`.
- Propagated Slack event `action_token` from Socket Mode events through slack-bot processing into Slack search.
- Kept query CLI and MCP Slack search gated on `SLACK_USER_TOKEN` because those entry points cannot obtain Slack event action tokens.
- Updated Slack token documentation, configuration examples, and Slack Go dependency (`github.com/slack-go/slack` v0.23.1).

## Motivation and Context
Slack `search.messages` requires a user token, but slack-bot mention events can use Slack's Real-time Search API with a bot token and short-lived event `action_token`. This lets slack-bot operate without `SLACK_USER_TOKEN` for public-channel search while clearly documenting that CLI/MCP still require a user token.

Related issue: N/A

## How Has This Been Tested?
- [x] Unit tests (`go test $(go list ./... | grep -v '/tests/') -timeout 120s`)
- [ ] Integration tests
- [ ] Manual testing with local setup
- [ ] Tested with AWS services (S3 Vectors, OpenSearch, Bedrock)

### Test Configuration
- Go version: go1.26.2 darwin/arm64
- AWS Region: N/A
- OpenSearch version (if applicable): N/A

## Impact Analysis
### Components Affected
- [x] CLI commands (`cmd/`)
- [ ] Vectorization (`internal/vectorizer/`)
- [ ] OpenSearch integration (`internal/opensearch/`)
- [ ] S3 Vector operations (`internal/s3vector/`)
- [x] Slack bot (`internal/slackbot/`)
- [ ] Bedrock embedding (`internal/embedding/`)
- [x] Configuration (`internal/config/`)

### AWS Resources Impact
- [x] No AWS resource changes
- [ ] S3 bucket operations
- [ ] OpenSearch index structure
- [ ] IAM permissions required
- [ ] Bedrock model usage

## Breaking Changes
- [x] None
- [ ] Yes (describe below)

### Migration Guide
No migration required. For user-tokenless slack-bot search, Slack app settings must provide event `action_token`s and `search:read.public` as documented in `docs/slack-user-token.md`.

## Dependencies
- [ ] No new dependencies
- [x] Dependencies added/updated (list below)
  - Updated `github.com/slack-go/slack` from v0.17.3 to v0.23.1 for assistant search API support.

## Documentation
- [x] README.md updated
- [ ] CLAUDE.md updated
- [x] Inline code comments added/updated
- [x] API documentation updated
- [x] Configuration examples updated

## Checklist
- [ ] My code follows the project's style guidelines (`go fmt ./...` and `go vet ./...`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have checked my code for any security issues or exposed secrets
- [ ] I have tested with the minimum supported Go version (1.23)
- [ ] I have run `go mod tidy` to clean up dependencies

## Performance Considerations
- [x] No performance impact
- [ ] Performance improved (describe metrics)
- [ ] Performance degraded but acceptable (explain trade-offs)

## Additional Notes
- CLI and MCP intentionally pass empty `SearchOptions{}` and continue to require `SLACK_USER_TOKEN` for Slack search.
- `PULL_REQUEST.md` is a temporary PR body file and is not committed.

## Screenshots/Logs
N/A

---

# プルリクエスト（日本語版）

## 概要
slack-bot のリクエストで Slack Real-time Search (`assistant.search.context`) を使えるよう、イベント由来の `action_token` を Slack 検索まで伝搬します。CLI/MCP の Slack 検索は引き続き User Token による `search.messages` 経路を使います。

## 変更の種類
- [ ] バグ修正（既存機能を破壊しない問題の修正）
- [x] 新機能（既存機能を破壊しない機能の追加）
- [ ] 破壊的変更（既存機能の動作に影響を与える修正や機能）
- [x] ドキュメント更新
- [ ] パフォーマンス改善
- [ ] リファクタリング（機能的変更なし）

## 実装された変更
- Slack `assistant.search.context` 用の `AssistantSearcher` と、`SearchOptions.ActionToken` に基づく検索 backend 選択を追加。
- Socket Mode イベントから `action_token` を抽出し、slack-bot 処理経由で Slack 検索へ伝搬。
- query CLI / MCP は Slack イベントの `action_token` を取得できないため、`SLACK_USER_TOKEN` 必須のままにした。
- Slack token のドキュメント、設定例、Slack Go 依存関係を更新。

## 動機と背景
Slack `search.messages` は User Token が必要ですが、slack-bot のメンションイベントでは Bot Token と短命の `action_token` で Real-time Search API を利用できます。これにより、User Token なしでも slack-bot では public channel 検索が可能になります。

関連 issue: N/A

## テスト方法
- [x] ユニットテスト（`go test $(go list ./... | grep -v '/tests/') -timeout 120s`）
- [ ] 統合テスト
- [ ] ローカル環境での手動テスト
- [ ] AWSサービス（S3 Vectors、OpenSearch、Bedrock）でのテスト

### テスト設定
- Goバージョン: go1.26.2 darwin/arm64
- AWSリージョン: N/A
- OpenSearchバージョン（該当する場合）: N/A

## 影響分析
### 影響を受けるコンポーネント
- [x] CLIコマンド（`cmd/`）
- [ ] ベクトル化（`internal/vectorizer/`）
- [ ] OpenSearch統合（`internal/opensearch/`）
- [ ] S3 Vector操作（`internal/s3vector/`）
- [x] Slack bot（`internal/slackbot/`）
- [ ] Bedrock埋め込み（`internal/embedding/`）
- [x] 設定（`internal/config/`）

### AWSリソースへの影響
- [x] AWSリソースの変更なし
- [ ] S3バケット操作
- [ ] OpenSearchインデックス構造
- [ ] IAM権限が必要
- [ ] Bedrockモデルの使用

## 破壊的変更
- [x] なし
- [ ] あり（以下に記述）

### 移行ガイド
移行不要です。User Token なしで slack-bot 検索を使う場合は、`docs/slack-user-token.md` に記載の通り Slack App がイベント `action_token` と `search:read.public` を提供する設定になっている必要があります。

## 依存関係
- [ ] 新しい依存関係なし
- [x] 依存関係の追加/更新（以下にリスト）
  - `assistant.search.context` API 対応のため `github.com/slack-go/slack` を v0.17.3 から v0.23.1 に更新。

## ドキュメント
- [x] README.md更新
- [ ] CLAUDE.md更新
- [x] インラインコードコメントの追加/更新
- [x] APIドキュメント更新
- [x] 設定例の更新

## チェックリスト
- [ ] コードがプロジェクトのスタイルガイドラインに従っている（`go fmt ./...` と `go vet ./...`）
- [x] 自分のコードをセルフレビューした
- [x] 理解が困難な領域にコメントを追加した
- [x] ドキュメントに対応する変更を行った
- [x] 変更によって新しい警告やエラーが生成されない
- [x] 修正が効果的であることまたは機能が動作することを証明するテストを追加した
- [x] 新しいテストと既存のユニットテストがローカルで成功する
- [ ] 依存する変更がマージされ公開されている
- [x] セキュリティ問題や露出した秘密情報がないかコードをチェックした
- [ ] サポートされる最小Goバージョン（1.23）でテストした
- [ ] `go mod tidy`を実行して依存関係をクリーンアップした

## パフォーマンスに関する考慮事項
- [x] パフォーマンスへの影響なし
- [ ] パフォーマンス改善（メトリクスを記述）
- [ ] パフォーマンス低下だが許容範囲（トレードオフを説明）

## 追加ノート
- CLI/MCP は意図的に空の `SearchOptions{}` を渡し、Slack 検索には引き続き `SLACK_USER_TOKEN` を要求します。
- `PULL_REQUEST.md` は PR 本文用の一時ファイルで、コミット対象ではありません。

## スクリーンショット/ログ
N/A
